### PR TITLE
Parse SimTK units with get_name instead of get_symbol

### DIFF
--- a/system/tests/test_utils.py
+++ b/system/tests/test_utils.py
@@ -8,13 +8,23 @@ from system.utils import simtk_to_pint, pint_to_simtk, compare_sympy_expr
 
 u = pint.UnitRegistry()
 
-def test_simtk_to_pint():
+simtk_quantitites = [
+    4.0 * simtk_unit.nanometer,
+    5.0 * simtk_unit.angstrom,
+]
+pint_quantities = [
+    4.0 * u.nanometer,
+    5.0 * u.angstrom,
+]
+@pytest.mark.parametrize(
+    'simtk_quantity,pint_quantity',
+    [(s, p) for s, p in zip(simtk_quantitites, pint_quantities)]
+)
+def test_simtk_to_pint(simtk_quantity, pint_quantity):
     """Test conversion from SimTK Quantity to pint Quantity."""
-    simtk_quantity = 10.0 * simtk_unit.nanometer
+    converted_pint_quantity = simtk_to_pint(simtk_quantity)
 
-    pint_quantity = simtk_to_pint(simtk_quantity)
-
-    assert pint_quantity == 10.0 * u.nanometer
+    assert pint_quantity == converted_pint_quantity
 
 def test_pint_to_simtk():
     """Test conversion from pint Quantity to SimTK Quantity."""

--- a/system/utils.py
+++ b/system/utils.py
@@ -18,7 +18,7 @@ def simtk_to_pint(simtk_quantity):
     simtk_value = simtk_quantity.value_in_unit(simtk_unit)
 
     u = pint.UnitRegistry()
-    pint_unit = u(simtk_unit.get_symbol())
+    pint_unit = u(simtk_unit.get_name())
     pint_quantity = simtk_value * pint_unit
 
     return pint_quantity


### PR DESCRIPTION
Fixes things like this

```
In [1]: from simtk import unit

In [2]: import pint

In [3]: u = pint.UnitRegistry()

In [4]: val = 5.0 * unit.angstrom

In [5]: u(val.unit.get_symbol())
Out[5]: 1 <Unit('ampere')>

In [6]: u(val.unit.get_name())
Out[6]: 1 <Unit('angstrom')>
```

and provides a better framework for expanding the coverage of the relevant unit test