### PR TITLE
Add Integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on:
   push:
@@ -63,7 +63,7 @@ jobs:
     - name: Run tests
       shell: bash -l {0}
       run: |
-        pytest -v --cov=openff/system --cov-report=xml --cov-config=setup.cfg openff/system/tests/
+        pytest -v --cov=openff/system/ --cov-report=xml --cov-config=setup.cfg openff/system/tests/ --ignore=openff/system/tests/integration_tests/
 
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,0 +1,70 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "master"
+      - "maintenance/.+"
+  pull_request:
+    branches:
+      - "master"
+      - "maintenance/.+"
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+        python-version: [3.6, 3.7]
+    env:
+      CI_OS: ${{ matrix.os }}
+      PYVER: ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: goanpeca/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        activate-environment: test
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+        environment-file: devtools/conda-envs/intermol_env.yaml
+        auto-activate-base: false
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+    - name: Environment Information
+      shell: bash -l {0}
+      run: |
+        conda info
+        conda list
+
+    - name: Install package
+      shell: bash -l {0}
+      run: |
+        python -m pip install --no-deps .
+
+    - name: Install development version of toolkit
+      shell: bash -l {0}
+      run: |
+        python -m pip install git+https://github.com/openforcefield/openforcefield
+
+    - name: Run tests
+      shell: bash -l {0}
+      run: |
+        pytest -v --cov=openff/system --cov-report=xml --cov-config=setup.cfg openff/system/tests/integration_tests/
+
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: Integration tests
 
 on:
   push:
@@ -61,7 +61,7 @@ jobs:
     - name: Run tests
       shell: bash -l {0}
       run: |
-        pytest -v --cov=openff/system --cov-report=xml --cov-config=setup.cfg openff/system/tests/integration_tests/
+        pytest -v --cov=openff/system/ --cov-report=xml --cov-config=setup.cfg openff/system/tests/integration_tests/
 
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/devtools/conda-envs/intermol_env.yaml
+++ b/devtools/conda-envs/intermol_env.yaml
@@ -1,0 +1,24 @@
+name: test
+channels:
+  - conda-forge
+  - omnia
+  - mwt
+
+dependencies:
+    # Base depends
+  - python
+  - pip
+  - pydantic
+  - pint
+  - sympy
+  - qcelemental
+
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov
+  - sympy
+  - pint
+  - openmm
+  - openforcefield>=0.7.0
+  - intermol

--- a/devtools/conda-envs/intermol_env.yaml
+++ b/devtools/conda-envs/intermol_env.yaml
@@ -2,6 +2,7 @@ name: test
 channels:
   - conda-forge
   - omnia
+  - bioconda
   - mwt
 
 dependencies:
@@ -22,3 +23,5 @@ dependencies:
   - openmm
   - openforcefield>=0.7.0
   - intermol
+  - gromacs
+  - lammps

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -15,7 +15,7 @@ def to_parmed(off_system: Any) -> pmd.Structure:
     for topology_molecule in off_system.topology.topology_molecules:
         for atom in topology_molecule.atoms:
             structure.add_atom(
-                pmd.Atom(atomic_number=atom.atomic_number), resname="", resnum=0
+                pmd.Atom(atomic_number=atom.atomic_number), resname="FOO", resnum=0
             )
 
     if "Bonds" in off_system.term_collection.terms:
@@ -111,6 +111,10 @@ def to_parmed(off_system: Any) -> pmd.Structure:
             .magnitude
         )
         pmd_atom.charge = partial_charge
+
+    # Assign dummy residue names, GROMACS will not accept empty strings
+    for res in structure.residues:
+        res.name = "FOO"
 
     structure.positions = off_system.positions.to(unit.angstrom).m
 

--- a/openff/system/tests/integration_tests/int.py
+++ b/openff/system/tests/integration_tests/int.py
@@ -54,6 +54,12 @@ def test_parmed_openmm():
             prefix="methane1",
         )
 
+        openff_pmd_gmx(
+            topology=top,
+            forcefield=parsley,
+            prefix="methane2",
+        )
+
         ener1, ener1_file = gmx_energy(
             top="methane1.top",
             gro="methane1.gro",

--- a/openff/system/tests/integration_tests/int.py
+++ b/openff/system/tests/integration_tests/int.py
@@ -1,0 +1,69 @@
+import tempfile
+
+import numpy as np
+import parmed as pmd
+from intermol.gromacs import energies as gmx_energy
+from openforcefield.topology import Molecule, Topology
+from openforcefield.typing.engines.smirnoff.forcefield import ForceField
+from pkg_resources import resource_filename
+from simtk import unit
+
+from ...system import System
+
+
+def openff_openmm_pmd_gmx(
+    topology: Topology, forcefield: ForceField, prefix: str
+) -> None:
+    """Pipeline to write GROMACS files from and OpenMM system through ParmEd"""
+    omm_sys = forcefield.create_openmm_system(topology)
+
+    struct = pmd.openmm.load_topology(
+        system=omm_sys,
+        topology=topology.to_openmm(),
+        xyz=topology.topology_molecules[0].reference_molecule.conformers[0],
+    )
+
+    struct.save(prefix + ".gro")
+    struct.save(prefix + ".top")
+
+
+def openff_pmd_gmx(
+    topology: Topology,
+    forcefield: ForceField,
+    prefix: str,
+) -> None:
+    off_sys = System.from_toolkit(topology=topology, forcefield=forcefield)
+
+    struct = off_sys.to_parmed()
+
+    struct.save(prefix + ".gro")
+    struct.save(prefix + ".top")
+
+
+def test_parmed_openmm():
+    parsley = ForceField("openff_unconstrained-1.0.0.offxml")
+    mol = Molecule.from_smiles("C")
+    mol.generate_conformers(n_conformers=1)
+    top = Topology.from_molecules(mol)
+    top.box_vectors = 4 * np.eye(3) * unit.nanometer
+
+    with tempfile.TemporaryDirectory():  # This probably doesn't work
+        openff_openmm_pmd_gmx(
+            topology=top,
+            forcefield=parsley,
+            prefix="methane1",
+        )
+
+        ener1, ener1_file = gmx_energy(
+            top="methane1.top",
+            gro="methane1.gro",
+            mdp=resource_filename("intermol", "tests/gromacs/grompp_vacuum.mdp"),
+        )
+
+        ener2, ener2_file = gmx_energy(
+            top="methane2.top",
+            gro="methane2.gro",
+            mdp=resource_filename("intermol", "tests/gromacs/grompp_vacuum.mdp"),
+        )
+
+        assert ener1 == ener2

--- a/openff/system/tests/integration_tests/test_interoperability_pathways.py
+++ b/openff/system/tests/integration_tests/test_interoperability_pathways.py
@@ -7,6 +7,7 @@ from pkg_resources import resource_filename
 from simtk import unit
 
 from ...system import System
+from ..utils import compare_energies
 
 
 def openff_openmm_pmd_gmx(
@@ -76,4 +77,4 @@ def test_parmed_openmm(tmpdir):
         mdp=resource_filename("intermol", "tests/gromacs/grompp.mdp"),
     )
 
-    assert ener1 == ener2
+    compare_energies(ener1, ener2)

--- a/openff/system/tests/utils.py
+++ b/openff/system/tests/utils.py
@@ -30,3 +30,13 @@ def top_from_smiles(
     # TODO: Revisit if/after Topology.is_periodic
     top.box_vectors = np.eye(3) * 10 * unit.nanometer
     return top
+
+
+def compare_energies(ener1, ener2):
+    """Compare two GROMACS energy dicts from InterMol"""
+    assert ener1.keys() == ener2.keys()
+    for key in ener1.keys():
+        assert np.isclose(
+            ener1[key] / ener1[key].unit,
+            ener2[key] / ener2[key].unit,
+        )


### PR DESCRIPTION
### Description
This adds a very basic and kinda hacky test that demonstrates how InterMol can be used for integration testing. The intent is to build this out for other engines and systems for a fairly dense matrix, similar to some of the tests in `intermol/tests/*/unit_tests/`