### PR TITLE
Fix codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Install package
       shell: bash -l {0}
       run: |
-        python -m pip install --no-deps .
+        python setup.py develop --no-deps
 
     - name: Install JAX if using Python 3.7
       if: ${{ matrix.python-version == 3.7 }}


### PR DESCRIPTION
### Description
This PR implements the fix in https://github.com/openforcefield/openff-recharge/pull/7. This should bring codecov back online, although we never figured out why.