### PR TITLE
Drop sympy for expression parsing

### DIFF
--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -55,3 +55,9 @@ class InterMolEnergyComparisonError(AssertionError):
     """
     Exception for when energies derived from InterMol do not match
     """
+
+
+class InvalidExpressionError(ValueError):
+    """
+    Exception for when an expression cannot safely be interpreted
+    """

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=numpy,sympy,openforcefield,pint,pytest,simtk
+known_third_party=numpy,sympy,openforcefield,pint,pytest,simtk,pydantic
 
 [versioneer]
 # Automatic version numbering scheme


### PR DESCRIPTION
### Description
This PR drops `sympy` as an expression validator until an appropriate solution to #56 can be found. It also makes some small improvements to the tests.