### PR TITLE
Use implicit units in models

### DIFF
--- a/openff/system/components/potentials.py
+++ b/openff/system/components/potentials.py
@@ -3,14 +3,13 @@ from typing import Dict, List, Optional, Set, Union
 import jax.numpy as jnp
 from pydantic import BaseModel, validator
 
-from openff.system import unit
 from openff.system.exceptions import InvalidExpressionError
 
 
 class Potential(BaseModel):
     """Base class for storing applied parameters"""
 
-    parameters: Dict[str, Optional[Union[unit.Quantity, List, int]]] = dict()
+    parameters: Dict[str, Optional[Union[List, float]]] = dict()
 
     class Config:
         arbitrary_types_allowed = True
@@ -48,7 +47,7 @@ class PotentialHandler(BaseModel):
     def get_force_field_parameters(self):
         params: list = list()
         for potential in self.potentials.values():
-            row = [val.magnitude for val in potential.parameters.values()]
+            row = [val for val in potential.parameters.values()]  # val.magnitude
             params.append(row)
 
         return jnp.array(params)

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -10,10 +10,14 @@ from openforcefield.typing.engines.smirnoff.parameters import (
     vdWHandler,
 )
 from pydantic import BaseModel
+from simtk import unit as omm_unit
 
-from openff.system import unit
 from openff.system.components.potentials import Potential, PotentialHandler
-from openff.system.utils import get_partial_charges_from_openmm_system, simtk_to_pint
+from openff.system.utils import get_partial_charges_from_openmm_system
+
+kcal_mol = omm_unit.kilocalorie_per_mole
+kcal_mol_angstroms = kcal_mol / omm_unit.angstrom ** 2
+kcal_mol_radians = kcal_mol / omm_unit.radian ** 2
 
 
 class SMIRNOFFConstraintHandler(PotentialHandler):
@@ -90,8 +94,8 @@ class SMIRNOFFBondHandler(PotentialHandler):
             parameter_type = parameter_handler.get_parameter({"smirks": smirks})[0]
             potential = Potential(
                 parameters={
-                    "k": simtk_to_pint(parameter_type.k),
-                    "length": simtk_to_pint(parameter_type.length),
+                    "k": parameter_type.k / kcal_mol_angstroms,
+                    "length": parameter_type.length / omm_unit.angstrom,
                 },
             )
             self.potentials[smirks] = potential
@@ -130,8 +134,8 @@ class SMIRNOFFAngleHandler(PotentialHandler):
             parameter_type = parameter_handler.get_parameter({"smirks": smirks})[0]
             potential = Potential(
                 parameters={
-                    "k": simtk_to_pint(parameter_type.k),
-                    "angle": simtk_to_pint(parameter_type.angle),
+                    "k": parameter_type.k / kcal_mol_radians,
+                    "angle": parameter_type.angle / omm_unit.degree,
                 },
             )
             self.potentials[smirks] = potential
@@ -177,9 +181,9 @@ class SMIRNOFFProperTorsionHandler(PotentialHandler):
                 identifier = key
                 potential = Potential(
                     parameters={
-                        "k": simtk_to_pint(parameter_type.k[n]),
+                        "k": parameter_type.k[n] / kcal_mol,
                         "periodicity": parameter_type.periodicity[n],
-                        "phase": simtk_to_pint(parameter_type.phase[n]),
+                        "phase": parameter_type.phase[n] / omm_unit.degree,
                     },
                 )
                 self.potentials[identifier] = potential
@@ -222,16 +226,16 @@ class SMIRNOFFvdWHandler(PotentialHandler):
             try:
                 potential = Potential(
                     parameters={
-                        "sigma": simtk_to_pint(parameter_type.sigma),
-                        "epsilon": simtk_to_pint(parameter_type.epsilon),
+                        "sigma": parameter_type.sigma / omm_unit.angstrom,
+                        "epsilon": parameter_type.epsilon / kcal_mol,
                     },
                 )
             except AttributeError:
                 # Handle rmin_half pending https://github.com/openforcefield/openforcefield/pull/750
                 potential = Potential(
                     parameters={
-                        "sigma": simtk_to_pint(parameter_type.rmin_half / 2 ** (1 / 6)),
-                        "epsilon": simtk_to_pint(parameter_type.epsilon),
+                        "sigma": parameter_type.sigma / omm_unit.angstrom,
+                        "epsilon": parameter_type.epsilon / kcal_mol,
                     },
                 )
             self.potentials[smirks] = potential
@@ -242,7 +246,7 @@ class SMIRNOFFElectrostaticsHandler(BaseModel):
     name: str = "Electrostatics"
     expression: str = "coul"
     independent_variables: Set[str] = {"r"}
-    charge_map: Dict[tuple, unit.Quantity] = dict()
+    charge_map: Dict[tuple, float] = dict()
     scale_13: float = 0.0
     scale_14: float = 0.8333333333
     scale_15: float = 1.0
@@ -259,7 +263,7 @@ class SMIRNOFFElectrostaticsHandler(BaseModel):
         """
         partial_charges = get_partial_charges_from_openmm_system(
             forcefield.create_openmm_system(topology=topology)
-        )
+        )  # / omm_unit.elementary_charge
 
         for i, charge in enumerate(partial_charges):
             self.charge_map[(i,)] = partial_charges[i]

--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import numpy as np
 from openforcefield.topology.topology import Topology
@@ -7,8 +7,6 @@ from simtk import unit as omm_unit
 
 from openff.system.components.potentials import PotentialHandler
 from openff.system.interop.parmed import to_parmed
-from openff.system.types import UnitArray
-from openff.system.utils import simtk_to_pint
 
 
 class System(BaseModel):
@@ -20,8 +18,8 @@ class System(BaseModel):
 
     handlers: Dict[str, PotentialHandler] = dict()
     topology: Optional[Topology] = None
-    box: Optional[UnitArray] = None
-    positions: Optional[UnitArray] = None
+    box: Optional[Union[omm_unit.Quantity, np.ndarray]] = None
+    positions: Optional[Union[omm_unit.Quantity, np.ndarray]] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -30,8 +28,10 @@ class System(BaseModel):
     def validate_box(cls, val):
         if val is None:
             return val
-        if type(val) == omm_unit.Quantity:
-            val = simtk_to_pint(val)
+        elif type(val) == omm_unit.Quantity:
+            val = val / omm_unit.nanometer
+        elif type(val) == np.ndarray:
+            pass
         if val.shape == (3, 3):
             return val
         elif val.shape == (3,):

--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -29,7 +29,7 @@ class System(BaseModel):
         if val is None:
             return val
         elif type(val) == omm_unit.Quantity:
-            val = val / omm_unit.nanometer
+            val /= omm_unit.nanometer
         elif type(val) == np.ndarray:
             pass
         if val.shape == (3, 3):

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -197,6 +197,7 @@ def _convert_box(box, structure: pmd.Structure) -> None:
         structure.box = [0, 0, 0, 90, 90, 90]
     else:
         lengths = box.diagonal()  # .to(unit("angstrom")).diagonal().magnitude
+        lengths = lengths * 10  # nm to Angstrom
         angles = 3 * [90]
         structure.box = np.hstack([lengths, angles])
 

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -42,8 +42,8 @@ def to_parmed(off_system: Any) -> pmd.Structure:
                 bond_type = bond_map[smirks]
             except KeyError:
                 pot = bond_handler.potentials[smirks]
-                k = pot.parameters["k"].m / 2
-                length = pot.parameters["length"].m
+                k = pot.parameters["k"] / 2  # .m
+                length = pot.parameters["length"]  # .m
                 bond_type = pmd.BondType(k=k, req=length)
                 bond_map[smirks] = bond_type
                 del pot, k, length
@@ -64,8 +64,8 @@ def to_parmed(off_system: Any) -> pmd.Structure:
             idx_1, idx_2, idx_3 = eval(angle)
             pot = angle_term.potentials[smirks]
             # TODO: Look at cost of redundant conversions, to ensure correct units of .m
-            k = pot.parameters["k"].magnitude / 2  # kcal/mol/rad**2
-            theta = pot.parameters["angle"].magnitude  # degree
+            k = pot.parameters["k"] / 2  # .magnitude, kcal/mol/rad**2
+            theta = pot.parameters["angle"]  # .magnitude, degree
             # TODO: Look up if AngleType already exists in struct
             angle_type = pmd.AngleType(k=k, theteq=theta)
             structure.angles.append(
@@ -93,9 +93,9 @@ def to_parmed(off_system: Any) -> pmd.Structure:
             idx_1, idx_2, idx_3, idx_4 = eval(proper)
             pot = proper_term.potentials[smirks]
             for n in range(pot.parameters["n_terms"]):
-                k = pot.parameters["k"][n].to(kcal_mol).magnitude
+                k = pot.parameters["k"][n]  # .to(kcal_mol).magnitude
                 periodicity = pot.parameters["periodicity"][n]
-                phase = pot.parameters["phase"][n].magnitude
+                phase = pot.parameters["phase"][n]  # .magnitude
                 dihedral_type = pmd.DihedralType(
                     phi_k=k,
                     per=periodicity,
@@ -173,9 +173,9 @@ def to_parmed(off_system: Any) -> pmd.Structure:
     for pmd_idx, pmd_atom in enumerate(structure.atoms):
         if has_electrostatics:
             partial_charge = electrostatics_handler.charge_map[(pmd_idx,)]
-            partial_charge_unitless = partial_charge.to(
-                unit.elementary_charge
-            ).magnitude
+            partial_charge_unitless = (
+                partial_charge  # .to(unit.elementary_charge).magnitude
+            )
             pmd_atom.charge = float(partial_charge_unitless)
             pmd_atom.atom_type.charge = float(partial_charge_unitless)
         else:
@@ -185,23 +185,24 @@ def to_parmed(off_system: Any) -> pmd.Structure:
     for res in structure.residues:
         res.name = "FOO"
 
-    structure.positions = off_system.positions.to(unit.angstrom).m
+    structure.positions = off_system.positions  # .to(unit.angstrom).m
 
     return structure
 
 
-def _convert_box(box: unit.Quantity, structure: pmd.Structure) -> None:
+# def _convert_box(box: unit.Quantity, structure: pmd.Structure) -> None:
+def _convert_box(box, structure: pmd.Structure) -> None:
     # TODO: Convert box vectors to box lengths + angles
     if box is None:
         structure.box = [0, 0, 0, 90, 90, 90]
     else:
-        lengths = box.to(unit("angstrom")).diagonal().magnitude
+        lengths = box.diagonal()  # .to(unit("angstrom")).diagonal().magnitude
         angles = 3 * [90]
         structure.box = np.hstack([lengths, angles])
 
 
 def _lj_params_from_potential(potential):
-    sigma = potential.parameters["sigma"].to(unit.angstrom).magnitude
-    epsilon = potential.parameters["epsilon"].to(kcal_mol).magnitude
+    sigma = potential.parameters["sigma"]  # .to(unit.angstrom).magnitude
+    epsilon = potential.parameters["epsilon"]  # .to(kcal_mol).magnitude
 
     return sigma, epsilon

--- a/openff/system/tests/integration_tests/test_interoperability_pathways.py
+++ b/openff/system/tests/integration_tests/test_interoperability_pathways.py
@@ -10,7 +10,6 @@ from pkg_resources import resource_filename
 from simtk import unit as omm_unit
 
 from openff.system.stubs import ForceField
-from openff.system.utils import simtk_to_pint
 
 from ..utils import compare_energies
 
@@ -49,9 +48,10 @@ def openff_pmd_gmx(
     topology.box_vectors = box
     off_sys = forcefield.create_openff_system(topology=topology)
 
-    off_top_positions = topology.topology_molecules[0].reference_molecule.conformers[0]
+    ref_mol = topology.topology_molecules[0].reference_molecule
+    off_top_positions = ref_mol.conformers[0]
     # TODO: Update this when better processing of OFFTop positions is supported
-    off_sys.positions = simtk_to_pint(off_top_positions)
+    off_sys.positions = off_top_positions / omm_unit.angstrom
 
     struct = off_sys.to_parmed()
 

--- a/openff/system/tests/test_interop/test_parmed.py
+++ b/openff/system/tests/test_interop/test_parmed.py
@@ -9,8 +9,7 @@ from openff.system.tests.utils import top_from_smiles
 class TestParmedConversion(BaseTest):
     @pytest.fixture()
     def box(self):
-        # UnitArray(np.array([4, 4, 4]), units="nanometer")
-        return np.array([40.0, 40.0, 40.0])
+        return np.array([4.0, 4.0, 4.0])
 
     def test_box(self, argon_ff, argon_top, box):
         off_sys = argon_ff.create_openff_system(topology=argon_top, box=box)

--- a/openff/system/tests/test_interop/test_parmed.py
+++ b/openff/system/tests/test_interop/test_parmed.py
@@ -4,23 +4,19 @@ import pytest
 from openff.system.stubs import ForceField
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.utils import top_from_smiles
-from openff.system.types import UnitArray
 
 
 class TestParmedConversion(BaseTest):
     @pytest.fixture()
     def box(self):
-        return UnitArray(np.array([4, 4, 4]), units="nanometer")
+        # UnitArray(np.array([4, 4, 4]), units="nanometer")
+        return np.array([40.0, 40.0, 40.0])
 
     def test_box(self, argon_ff, argon_top, box):
-        sys_out = argon_ff.create_openff_system(topology=argon_top, box=box)
-        sys_out.positions = UnitArray(
-            np.zeros(
-                shape=(argon_top.n_topology_atoms, 3),
-            ),
-            units="angstrom",
-        )
-        struct = sys_out.to_parmed()
+        off_sys = argon_ff.create_openff_system(topology=argon_top, box=box)
+        # UnitArray(...)
+        off_sys.positions = np.zeros(shape=(argon_top.n_topology_atoms, 3))
+        struct = off_sys.to_parmed()
 
         assert np.allclose(
             struct.box[:3],
@@ -28,14 +24,10 @@ class TestParmedConversion(BaseTest):
         )
 
     def test_basic_conversion_argon(self, argon_ff, argon_top, box):
-        sys_out = argon_ff.create_openff_system(argon_top, box=box)
-        sys_out.positions = UnitArray(
-            np.zeros(
-                shape=(argon_top.n_topology_atoms, 3),
-            ),
-            units="angstrom",
-        )
-        struct = sys_out.to_parmed()
+        off_sys = argon_ff.create_openff_system(argon_top, box=box)
+        # UnitArray(...)
+        off_sys.positions = np.zeros(shape=(argon_top.n_topology_atoms, 3))
+        struct = off_sys.to_parmed()
 
         # As partial sanity check, see if it they save without error
         struct.save("x.top", combine="all")
@@ -48,12 +40,8 @@ class TestParmedConversion(BaseTest):
         parsley = ForceField("openff_unconstrained-1.0.0.offxml")
 
         off_sys = parsley.create_openff_system(topology=top, box=box)
-        off_sys.positions = UnitArray(
-            np.zeros(
-                shape=(top.n_topology_atoms, 3),
-            ),
-            units="angstrom",
-        )
+        # UnitArray(...)
+        off_sys.positions = np.zeros(shape=(top.n_topology_atoms, 3))
         struct = off_sys.to_parmed()
 
         sigma0 = struct.atoms[0].atom_type.sigma

--- a/openff/system/tests/test_potential.py
+++ b/openff/system/tests/test_potential.py
@@ -6,7 +6,6 @@ from simtk import unit as omm_unit
 
 from openff.system.components.potentials import PotentialHandler
 from openff.system.tests.base_test import BaseTest
-from openff.system.utils import simtk_to_pint
 
 
 class TestBondPotentialHandler(BaseTest):
@@ -41,9 +40,8 @@ class TestBondPotentialHandler(BaseTest):
         bond_potentials = forcefield["Bonds"].create_potential(top)
 
         pot = bond_potentials.potentials[bond_potentials.slot_map["(0, 1)"]]
-        kcal_ang2_mol = omm_unit.kilocalorie_per_mole / omm_unit.angstrom ** 2
 
-        assert pot.parameters["k"] == simtk_to_pint(1.5 * kcal_ang2_mol)
+        assert pot.parameters["k"] == pytest.approx(1.5)
 
     def test_angle_potential_handler(self):
         top = Topology.from_molecules(Molecule.from_smiles("CCC"))
@@ -51,7 +49,7 @@ class TestBondPotentialHandler(BaseTest):
         angle_handler = AngleHandler(version=0.3)
         angle_parameter = AngleHandler.AngleType(
             smirks="[*:1]~[*:2]~[*:3]",
-            k=2.5 * omm_unit.kilocalorie_per_mole / omm_unit.degree ** 2,
+            k=2.5 * omm_unit.kilocalorie_per_mole / omm_unit.radian ** 2,
             angle=100 * omm_unit.degree,
             id="b1000",
         )
@@ -64,6 +62,5 @@ class TestBondPotentialHandler(BaseTest):
         angle_potentials = forcefield["Angles"].create_potential(top)
 
         pot = angle_potentials.potentials[angle_potentials.slot_map["(0, 1, 2)"]]
-        kcal_deg2_mol = omm_unit.kilocalorie_per_mole / omm_unit.degree ** 2
 
-        assert pot.parameters["k"] == simtk_to_pint(2.5 * kcal_deg2_mol)
+        assert pot.parameters["k"] == pytest.approx(2.5)

--- a/openff/system/tests/test_utils.py
+++ b/openff/system/tests/test_utils.py
@@ -86,6 +86,7 @@ class TestOpenMM(BaseTest):
         omm_system = argon_ff.create_openmm_system(argon_top)
         partial_charges = get_partial_charges_from_openmm_system(omm_system)
 
-        assert isinstance(partial_charges, unit.Quantity)
-        assert partial_charges.units == unit.elementary_charge
-        assert np.allclose(partial_charges.magnitude, np.zeros(4))
+        # assert isinstance(partial_charges, unit.Quantity)
+        # assert partial_charges.units == unit.elementary_charge
+        assert isinstance(partial_charges, list)
+        assert np.allclose(partial_charges, np.zeros(4))  # .magnitude

--- a/openff/system/utils.py
+++ b/openff/system/utils.py
@@ -7,10 +7,10 @@ from openforcefield.typing.engines.smirnoff import ForceField
 from openforcefield.utils import unit_to_string
 from pkg_resources import resource_filename
 from simtk import openmm
-from simtk import unit as simtk_unit
+from simtk import unit as omm_unit
 
-from . import unit
-from .types import UnitArray
+from openff.system import unit
+from openff.system.types import UnitArray
 
 
 def pint_to_simtk(quantity):
@@ -26,7 +26,7 @@ def simtk_to_pint(simtk_quantity):
     as part of the OpenFF Evaluator, Copyright (c) 2019 Open Force Field Consortium.
     """
     if isinstance(simtk_quantity, List):
-        simtk_quantity = simtk_unit.Quantity(simtk_quantity)
+        simtk_quantity = omm_unit.Quantity(simtk_quantity)
     openmm_unit = simtk_quantity.unit
     openmm_value = simtk_quantity.value_in_unit(openmm_unit)
 
@@ -75,10 +75,12 @@ def get_partial_charges_from_openmm_system(omm_system):
     n_particles = omm_system.getNumParticles()
     force = get_nonbonded_force_from_openmm_system(omm_system)
     # TODO: don't assume the partial charge will always be parameter 0
+    # partial_charges = [simtk_to_pint(force.getParticleParameters(idx)[0]) for idx in range(n_particles)]
     partial_charges = [
-        simtk_to_pint(force.getParticleParameters(idx)[0]) for idx in range(n_particles)
+        force.getParticleParameters(idx)[0] / omm_unit.elementary_charge
+        for idx in range(n_particles)
     ]
-    partial_charges = unit.Quantity.from_list(partial_charges)
+
     return partial_charges
 
 


### PR DESCRIPTION
## Description
This PR removes the half-measures of scattered unit implementations until we can arrive at a solution that is more suitable and general for the rest of the OpenFF software stack.

Related #60