### PR TITLE
Make SMIRNOFFElectrostaticsHandler use str keys

### DIFF
--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -246,7 +246,7 @@ class SMIRNOFFElectrostaticsHandler(BaseModel):
     name: str = "Electrostatics"
     expression: str = "coul"
     independent_variables: Set[str] = {"r"}
-    charge_map: Dict[tuple, float] = dict()
+    charge_map: Dict[str, float] = dict()
     scale_13: float = 0.0
     scale_14: float = 0.8333333333
     scale_15: float = 1.0
@@ -266,7 +266,7 @@ class SMIRNOFFElectrostaticsHandler(BaseModel):
         )  # / omm_unit.elementary_charge
 
         for i, charge in enumerate(partial_charges):
-            self.charge_map[(i,)] = charge
+            self.charge_map[str((i,))] = charge
 
     class Config:
         arbitrary_types_allowed = True

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -172,7 +172,7 @@ def to_parmed(off_system: Any) -> pmd.Structure:
 
     for pmd_idx, pmd_atom in enumerate(structure.atoms):
         if has_electrostatics:
-            partial_charge = electrostatics_handler.charge_map[(pmd_idx,)]
+            partial_charge = electrostatics_handler.charge_map[str((pmd_idx,))]
             partial_charge_unitless = (
                 partial_charge  # .to(unit.elementary_charge).magnitude
             )


### PR DESCRIPTION
### Description
This PR implements the change in #51 for the current `SMIRNOFFElectrostaticsHandler`, which I neglected to do (probably because of different attribute names).