### PR TITLE
Test on Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/devtools/conda-envs/intermol_env.yaml
+++ b/devtools/conda-envs/intermol_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - sympy
   - pint
   - openmm
-  - openforcefield>=0.7.0
+  - openforcefield >=0.7.0
   - intermol
   - gromacs
   - lammps

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,6 +19,6 @@ dependencies:
   - codecov
   - sympy
   - pint
-  - openmm
-  - openforcefield>=0.7.2
+  - openmm >= 7.5
+  - openforcefield >=0.7.2
   - nbval


### PR DESCRIPTION
### Description
This PR attempts to add Python 3.8 and 3.9 to CI, now that OpenMM's migration to `conda-forge` has  unblocked much of our dependencies.