### PR TITLE
Update OpenMM tests and nonbonded methods

### DIFF
--- a/openff/system/tests/test_interop/test_openmm.py
+++ b/openff/system/tests/test_interop/test_openmm.py
@@ -23,6 +23,8 @@ def test_from_openmm_single_mols(periodic, mol, n_mols):
     mol = Molecule.from_smiles(mol)
     mol.generate_conformers(n_conformers=1)
     top = Topology.from_molecules(n_mols * [mol])
+    mol.conformers[0] -= np.min(mol.conformers) * unit.angstrom
+
     if periodic:
         top.box_vectors = np.eye(3) * np.asarray([10, 10, 10]) * unit.nanometer
     else:
@@ -34,6 +36,7 @@ def test_from_openmm_single_mols(periodic, mol, n_mols):
         positions = np.vstack(
             [mol.conformers[0], mol.conformers[0] + 3 * unit.nanometer]
         )
+        positions = positions * unit.nanometer
 
     toolkit_system = parsley.create_openmm_system(top)
 

--- a/openff/system/tests/test_interop/test_openmm.py
+++ b/openff/system/tests/test_interop/test_openmm.py
@@ -36,7 +36,7 @@ def test_from_openmm_single_mols(periodic, mol, n_mols):
         positions = np.vstack(
             [mol.conformers[0], mol.conformers[0] + 3 * unit.nanometer]
         )
-        positions = positions * unit.nanometer
+        positions = positions * unit.angstrom
 
     toolkit_system = parsley.create_openmm_system(top)
 

--- a/openff/system/tests/test_interop/test_openmm.py
+++ b/openff/system/tests/test_interop/test_openmm.py
@@ -1,13 +1,15 @@
 import numpy as np
 import pytest
+from openforcefield.tests.utils import compare_system_energies
 from openforcefield.topology import Molecule, Topology
-from simtk import openmm, unit
+from simtk import unit
 
 from openff.system.stubs import ForceField
 
 
+@pytest.mark.parametrize("periodic", [True, False])
 @pytest.mark.parametrize("mol,n_mols", [("C", 1), ("CC", 1), ("C", 2), ("CC", 2)])
-def test_from_openmm_single_mols(mol, n_mols):
+def test_from_openmm_single_mols(periodic, mol, n_mols):
     """
     Test that ForceField.create_openmm_system and System.to_openmm produce
     objects with similar energies
@@ -21,7 +23,10 @@ def test_from_openmm_single_mols(mol, n_mols):
     mol = Molecule.from_smiles(mol)
     mol.generate_conformers(n_conformers=1)
     top = Topology.from_molecules(n_mols * [mol])
-    top.box_vectors = np.asarray([4, 4, 4]) * unit.nanometer
+    if periodic:
+        top.box_vectors = np.eye(3) * np.asarray([4, 4, 4]) * unit.nanometer
+    else:
+        top.box_vectors = None
 
     if n_mols == 1:
         positions = mol.conformers[0]
@@ -30,23 +35,14 @@ def test_from_openmm_single_mols(mol, n_mols):
             [mol.conformers[0], mol.conformers[0] + 2 * unit.nanometer]
         )
 
-    toolkit_energy = _get_energy_from_openmm_system(
-        openmm_sys=parsley.create_openmm_system(top),
-        openmm_top=top.to_openmm(),
-        positions=positions,
-    )
+    toolkit_system = parsley.create_openmm_system(top)
 
-    system_energy = _get_energy_from_openmm_system(
-        openmm_sys=parsley.create_openff_system(top).to_openmm(),
-        openmm_top=top.to_openmm(),
-        positions=positions,
-    )
+    native_system = parsley.create_openff_system(top).to_openmm()
 
-    np.testing.assert_allclose(
-        toolkit_energy / unit.kilojoule_per_mole,
-        system_energy / unit.kilojoule_per_mole,
-        rtol=1e-4,
-        atol=1e-4,
+    compare_system_energies(
+        system1=toolkit_system,
+        system2=native_system,
+        positions=positions,
     )
 
 
@@ -63,18 +59,3 @@ def test_unsupported_handler():
     with pytest.raises(NotImplementedError):
         # TODO: Catch this at openff_sys.to_openmm, not upstream
         parsley.create_openff_system(top)
-
-
-def _get_energy_from_openmm_system(openmm_sys, openmm_top, positions):
-    integrator = openmm.VerletIntegrator(1 * unit.femtoseconds)
-
-    platform = openmm.Platform.getPlatformByName("Reference")
-    simulation = openmm.app.Simulation(openmm_top, openmm_sys, integrator, platform)
-    simulation.context.setPositions(positions)
-
-    state = simulation.context.getState(getEnergy=True)
-    energy = state.getPotentialEnergy()
-
-    del integrator, platform, simulation, state
-
-    return energy

--- a/openff/system/tests/test_interop/test_openmm.py
+++ b/openff/system/tests/test_interop/test_openmm.py
@@ -43,6 +43,7 @@ def test_from_openmm_single_mols(periodic, mol, n_mols):
         system1=toolkit_system,
         system2=native_system,
         positions=positions,
+        box_vectors=top.box_vectors,
     )
 
 

--- a/openff/system/tests/test_interop/test_openmm.py
+++ b/openff/system/tests/test_interop/test_openmm.py
@@ -24,7 +24,7 @@ def test_from_openmm_single_mols(periodic, mol, n_mols):
     mol.generate_conformers(n_conformers=1)
     top = Topology.from_molecules(n_mols * [mol])
     if periodic:
-        top.box_vectors = np.eye(3) * np.asarray([4, 4, 4]) * unit.nanometer
+        top.box_vectors = np.eye(3) * np.asarray([10, 10, 10]) * unit.nanometer
     else:
         top.box_vectors = None
 
@@ -32,7 +32,7 @@ def test_from_openmm_single_mols(periodic, mol, n_mols):
         positions = mol.conformers[0]
     elif n_mols == 2:
         positions = np.vstack(
-            [mol.conformers[0], mol.conformers[0] + 2 * unit.nanometer]
+            [mol.conformers[0], mol.conformers[0] + 3 * unit.nanometer]
         )
 
     toolkit_system = parsley.create_openmm_system(top)


### PR DESCRIPTION
### Description
This PR updates the OpenMM export tests and also fixes setting the nonbonded methods in the `NonbondedForce` when the vdW and Electrostatics cutoff methods in the SMIRNOFF force field are set to `Cutoff` and `PME`, respectively (the default/common case).

When working on #69 I was frustrated by how difficult OpenMM made comparing energies - turns out I was simply disregarding existing functionality in the OpenFF Toolkit. Thanks @j-wags
