### PR TITLE
Update Python versions in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}


### PR DESCRIPTION
### Description
This PR drops Python 3.9 from CI, since those environments were falling back to 3.8, and ticks up the minor versions used in integration tests.