### PR TITLE
Add unit models

### DIFF
--- a/openff/system/stubs.py
+++ b/openff/system/stubs.py
@@ -27,13 +27,12 @@ from openff.system.components.smirnoff import (
 )
 from openff.system.components.system import System
 from openff.system.exceptions import SMIRNOFFHandlerNotImplementedError
-from openff.system.types import UnitArray
 
 
 def to_openff_system(
     self,
     topology: Topology,
-    box: Optional[Union[omm_unit.Quantity, UnitArray]] = None,
+    box: Optional[Union[omm_unit.Quantity]] = None,
     **kwargs,
 ) -> System:
     """

--- a/openff/system/tests/test_interop/test_parmed.py
+++ b/openff/system/tests/test_interop/test_parmed.py
@@ -13,7 +13,6 @@ class TestParmedConversion(BaseTest):
 
     def test_box(self, argon_ff, argon_top, box):
         off_sys = argon_ff.create_openff_system(topology=argon_top, box=box)
-        # UnitArray(...)
         off_sys.positions = np.zeros(shape=(argon_top.n_topology_atoms, 3))
         struct = off_sys.to_parmed()
 
@@ -24,7 +23,6 @@ class TestParmedConversion(BaseTest):
 
     def test_basic_conversion_argon(self, argon_ff, argon_top, box):
         off_sys = argon_ff.create_openff_system(argon_top, box=box)
-        # UnitArray(...)
         off_sys.positions = np.zeros(shape=(argon_top.n_topology_atoms, 3))
         struct = off_sys.to_parmed()
 

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -66,6 +66,16 @@ class TestFloatQuantity:
             "bar": '{"val": 90.0, "unit": "degree"}',
         }
 
+    @pytest.mark.parametrize("val", [True, [1]])
+    def test_bad_float_quantity_type(self, val):
+        class Atom(DefaultModel):
+            mass: FloatQuantity["atomic_mass_constant"]
+
+        with pytest.raises(
+            ValueError, match=r"Could not validate data of type .*[bool|list].*"
+        ):
+            Atom(mass=True)
+
     def test_array_quantity_model(self):
         class Molecule(DefaultModel):
             masses: ArrayQuantity["atomic_mass_constant"]
@@ -101,3 +111,13 @@ class TestFloatQuantity:
                 assert getattr(m, key) == getattr(parsed, key)
             except ValueError:
                 assert all(getattr(m, key) == getattr(parsed, key))
+
+    @pytest.mark.parametrize("val", [True, [1]])
+    def test_bad_array_quantity_type(self, val):
+        class Atom(DefaultModel):
+            mass: ArrayQuantity["atomic_mass_constant"]
+
+        with pytest.raises(
+            ValueError, match=r"Could not validate data of type .*[bool|list].*"
+        ):
+            Atom(mass=True)

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -121,3 +121,27 @@ class TestFloatQuantity:
             ValueError, match=r"Could not validate data of type .*[bool|list].*"
         ):
             Atom(mass=True)
+
+    def test_float_and_quantity_type(self):
+        class MixedModel(DefaultModel):
+            scalar_data: FloatQuantity
+            array_data: ArrayQuantity
+            name: str
+
+        m = MixedModel(
+            scalar_data=1.0 * unit.meter, array_data=[-1, 0] * unit.second, name="foo"
+        )
+
+        assert json.loads(m.json()) == {
+            "scalar_data": '{"val": 1.0, "unit": "meter"}',
+            "array_data": '{"val": [-1, 0], "unit": "second"}',
+            "name": "foo",
+        }
+
+        parsed = MixedModel.parse_raw(m.json())
+
+        for key in m.dict().keys():
+            try:
+                assert getattr(m, key) == getattr(parsed, key)
+            except ValueError:
+                assert all(getattr(m, key) == getattr(parsed, key))

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -38,7 +38,7 @@ class TestUnitArray:
             UnitArray([4, 4], units=input)
 
 
-class TestFloatQuantity:
+class TestQuantityTypes:
     def test_float_quantity_model(self):
         class Atom(DefaultModel):
             mass: FloatQuantity["atomic_mass_constant"]
@@ -66,6 +66,11 @@ class TestFloatQuantity:
             "bar": '{"val": 90.0, "unit": "degree"}',
         }
 
+        parsed = Atom.parse_raw(a.json())
+        assert a == parsed
+
+        assert Atom(**a.dict()) == a
+
     @pytest.mark.parametrize("val", [True, [1]])
     def test_bad_float_quantity_type(self, val):
         class Atom(DefaultModel):
@@ -86,7 +91,7 @@ class TestFloatQuantity:
 
         m = Molecule(
             masses=[16, 1, 1],
-            charges=[-1, 0.5, 0.5],
+            charges=np.asarray([-1, 0.5, 0.5]),
             foo=np.array([2.0, -2.0, 0.0]) * unit.nanometer,
             bar=[0, 90, 180],
             baz=np.array([3, 2, 1]).tobytes(),

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -2,40 +2,9 @@ import json
 
 import numpy as np
 import pytest
-from pydantic import BaseModel
 
 from openff.system import unit
-from openff.system.types import ArrayQuantity, DefaultModel, FloatQuantity, UnitArray
-
-
-class UnitModel(BaseModel):
-
-    any_values: UnitArray
-    distance_values: UnitArray[unit.nm]
-    time_values: UnitArray[unit.ns]
-
-
-class TestUnitArray:
-    def test_pint_model(self):
-
-        model = UnitModel(
-            any_values=[4, 2, 1] * unit.year,
-            distance_values=[1, 2] * unit.nm,
-            time_values=[2.0, 4.0] * unit.ns,
-        )
-
-        assert model.any_values.units == unit.year
-        assert model.distance_values.units == unit.nm
-        assert model.time_values.units == unit.ns
-
-    @pytest.mark.parametrize("default_unit", [unit.second, unit.liter, unit.meter])
-    def test_default_units(self, default_unit):
-        assert UnitArray([1, 1, 1], units=default_unit).units == default_unit
-
-    @pytest.mark.parametrize("input", [0, int, type(None)])
-    def test_bad_inputs(self, input):
-        with pytest.raises(TypeError):
-            UnitArray([4, 4], units=input)
+from openff.system.types import ArrayQuantity, DefaultModel, FloatQuantity
 
 
 class TestQuantityTypes:

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -89,3 +89,15 @@ class TestFloatQuantity:
             "bar": '{"val": [0, 90, 180], "unit": "degree"}',
             "baz": '{"val": [3, 2, 1], "unit": "second"}',
         }
+
+        parsed = Molecule.parse_raw(m.json())
+
+        # TODO: Better Model __eq__; pydantic just looks at their .dicts, which doesn't
+        # play nicely with arrays out of the box
+        assert parsed.__fields__ == m.__fields__
+
+        for key in m.dict().keys():
+            try:
+                assert getattr(m, key) == getattr(parsed, key)
+            except ValueError:
+                assert all(getattr(m, key) == getattr(parsed, key))

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -43,15 +43,24 @@ class TestFloatQuantity:
             mass: FloatQuantity["atomic_mass_constant"]
             charge: FloatQuantity["elementary_charge"]
             foo: FloatQuantity
+            bar: FloatQuantity["degree"]
 
-        a = Atom(mass=4, charge=0 * unit.elementary_charge, foo=2.0 * unit.nanometer)
+        a = Atom(
+            mass=4,
+            charge=0 * unit.elementary_charge,
+            foo=2.0 * unit.nanometer,
+            bar="90.0 degree",
+        )
 
         assert a.mass == 4 * unit.atomic_mass_constant
         assert a.charge == 0 * unit.elementary_charge
+        assert a.foo == 2.0 * unit.nanometer
+        assert a.bar == 90 * unit.degree
 
         # TODO: Update with custom deserialization to == a.dict()
         assert json.loads(a.json()) == {
             "mass": '{"val": 4, "unit": "atomic_mass_constant"}',
             "charge": '{"val": 0, "unit": "elementary_charge"}',
             "foo": '{"val": 2.0, "unit": "nanometer"}',
+            "bar": '{"val": 90.0, "unit": "degree"}',
         }

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel
 
 from openff.system import unit
@@ -46,23 +47,82 @@ class FloatQuantity(float, metaclass=_FloatQuantityMeta):
                 return unit.Quantity(val).to(unit_)
 
 
-class FloatQuantityEncoder(json.JSONEncoder):
+class QuantityEncoder(json.JSONEncoder):
+    """JSON encoder for unit-wrapped floats and np arrays. Should work
+    for both FloatQuantity and ArrayQuantity"""
+
     def default(self, obj):
         if isinstance(obj, unit.Quantity):
+            if isinstance(obj.magnitude, (float, int)):
+                data = obj.magnitude
+            elif isinstance(obj.magnitude, np.ndarray):
+                data = obj.magnitude.tolist()
+            else:
+                # This shouldn't ever be hit if our object models
+                # behave in ways we expect?
+                raise Exception(
+                    f"trying to serialize unsupported type {type(obj.magnitude)}"
+                )
             return {
-                "val": obj.magnitude,
+                "val": data,
                 "unit": str(obj.units),
             }
         return json.JSONEncoder.default(self, obj)
 
 
 def custom_quantity_encoder(v):
-    return json.dumps(v, cls=FloatQuantityEncoder)
+    return json.dumps(v, cls=QuantityEncoder)
+
+
+class _ArrayQuantityMeta(type):
+    def __getitem__(self, t):
+        return type("ArrayQuantity", (ArrayQuantity,), {"__unit__": t})
+
+
+class ArrayQuantity(float, metaclass=_ArrayQuantityMeta):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate_type
+
+    @classmethod
+    def validate_type(cls, val):
+        unit_ = getattr(cls, "__unit__", Any)
+        if unit_ is Any:
+            if isinstance(val, np.ndarray):
+                # input doesn't have a unit, it's just a float-ish type
+                raise ValueError("This needs unit")
+            elif isinstance(val, unit.Quantity):
+                # Redundant cast? Maybe this handles pint vs openff.system.unit?
+                return unit.Quantity(val)
+            else:
+                raise ValueError(
+                    f"Bad input, expected ndarray or pint.Quantity-like, got {type(val)})"
+                )
+        else:
+            unit_ = unit(unit_)
+            if isinstance(val, unit.Quantity):
+                assert unit_.dimensionality == val.dimensionality
+                return val.to(unit_)
+            elif isinstance(val, np.ndarray):
+                return val * unit_
+            elif isinstance(val, list):
+                return np.array(val) * unit_
+            elif isinstance(val, bytes):
+                # Define outside loop
+                dt = np.dtype(int)
+                dt.newbyteorder("<")
+                return np.frombuffer(val, dtype=dt) * unit_
+            elif isinstance(val, str):
+                # could do custom deserialization here?
+                raise NotImplementedError
+                #  return unit.Quantity(val).to(unit_)
 
 
 class DefaultModel(BaseModel):
     class Config:
-        json_encoders = {unit.Quantity: custom_quantity_encoder}
+        json_encoders = {
+            unit.Quantity: custom_quantity_encoder,
+        }
 
 
 class UnitArrayMeta(type):

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -40,11 +40,13 @@ class FloatQuantity(float, metaclass=_FloatQuantityMeta):
                 # could return here, without converting
                 # (could be inconsistent with data model - heteregenous but compatible units)
                 # return val
-            elif isinstance(val, (float, int)):
+            elif isinstance(val, (float, int)) and not isinstance(val, bool):
                 return val * unit_
             elif isinstance(val, str):
                 # could do custom deserialization here?
                 return unit.Quantity(val).to(unit_)
+            else:
+                raise ValueError(f"Could not validate data of type {type(val)}")
 
 
 class QuantityEncoder(json.JSONEncoder):
@@ -131,6 +133,8 @@ class ArrayQuantity(float, metaclass=_ArrayQuantityMeta):
                 # could do custom deserialization here?
                 raise NotImplementedError
                 #  return unit.Quantity(val).to(unit_)
+            else:
+                raise ValueError(f"Could not validate data of type {type(val)}")
 
 
 class DefaultModel(BaseModel):

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -76,18 +76,21 @@ def custom_quantity_encoder(v):
     return json.dumps(v, cls=QuantityEncoder)
 
 
-def json_loader(data):
+def json_loader(data: str) -> dict:
+    # TODO: recursively call this function for nested models
     data = json.loads(data)
     for key, val in data.items():
         try:
+            # Directly look for an encoded FloatQuantity/ArrayQuantity,
+            # which is itself a dict
             v = json.loads(val)
-            if "unit" in v:
-                unit_ = unit(v["unit"])
-                val = v["val"]
-                data[key] = unit_ * val
-        except Exception as e:
-            # TODO: Figure out what cases to catch here
-            raise e
+        except json.JSONDecodeError:
+            # Handles some cases of the val being a primitive type
+            continue
+        # TODO: More gracefully parse non-FloatQuantity/ArrayQuantity dicts
+        unit_ = unit(v["unit"])
+        val = v["val"]
+        data[key] = unit_ * val
     return data
 
 

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -21,15 +21,13 @@ class FloatQuantity(float, metaclass=_FloatQuantityMeta):
     def validate_type(cls, val):
         unit_ = getattr(cls, "__unit__", Any)
         if unit_ is Any:
-            if isinstance(val, float):
-                # input doesn't have a unit, it's just a float-ish type
-                raise ValueError("This needs unit")
+            if isinstance(val, (float, int)):
+                # TODO: Can this exception be raised with knowledge of the field it's in?
+                raise ValueError(f"Value {val} needs to be tagged with a unit")
             elif isinstance(val, unit.Quantity):
                 return unit.Quantity(val)
             else:
-                raise ValueError(
-                    f"Bad input, expected float or pint.Quantity-like, got {type(val)})"
-                )
+                raise ValueError(f"Could not validate data of type {type(val)}")
         else:
             unit_ = unit(unit_)
             if isinstance(val, unit.Quantity):
@@ -69,7 +67,6 @@ class QuantityEncoder(json.JSONEncoder):
                 "val": data,
                 "unit": str(obj.units),
             }
-        return json.JSONEncoder.default(self, obj)
 
 
 def custom_quantity_encoder(v):
@@ -108,16 +105,14 @@ class ArrayQuantity(float, metaclass=_ArrayQuantityMeta):
     def validate_type(cls, val):
         unit_ = getattr(cls, "__unit__", Any)
         if unit_ is Any:
-            if isinstance(val, np.ndarray):
-                # input doesn't have a unit, it's just a float-ish type
-                raise ValueError("This needs unit")
+            if isinstance(val, (list, np.ndarray)):
+                # TODO: Can this exception be raised with knowledge of the field it's in?
+                raise ValueError(f"Value {val} needs to be tagged with a unit")
             elif isinstance(val, unit.Quantity):
                 # Redundant cast? Maybe this handles pint vs openff.system.unit?
                 return unit.Quantity(val)
             else:
-                raise ValueError(
-                    f"Bad input, expected ndarray or pint.Quantity-like, got {type(val)})"
-                )
+                raise ValueError(f"Could not validate data of type {type(val)}")
         else:
             unit_ = unit(unit_)
             if isinstance(val, unit.Quantity):

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -123,10 +123,8 @@ class ArrayQuantity(float, metaclass=_ArrayQuantityMeta):
             if isinstance(val, unit.Quantity):
                 assert unit_.dimensionality == val.dimensionality
                 return val.to(unit_)
-            elif isinstance(val, np.ndarray):
+            elif isinstance(val, (np.ndarray, list)):
                 return val * unit_
-            elif isinstance(val, list):
-                return np.array(val) * unit_
             elif isinstance(val, bytes):
                 # Define outside loop
                 dt = np.dtype(int)
@@ -146,6 +144,7 @@ class DefaultModel(BaseModel):
             unit.Quantity: custom_quantity_encoder,
         }
         json_loads = json_loader
+        validate_assignment = True
 
 
 class UnitArrayMeta(type):

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -145,33 +145,3 @@ class DefaultModel(BaseModel):
         }
         json_loads = json_loader
         validate_assignment = True
-
-
-class UnitArrayMeta(type):
-    # TODO: would be nice to be able to sneak dtype and/or units in here
-    def __getitem__(self, units, dtype=None):
-        return type("UnitArray", (UnitArray,), {"_dtype": dtype, "_units": units})
-
-
-class UnitArray(unit.Quantity, metaclass=UnitArrayMeta):
-    """
-    Thin wrapper around pint.Quantity for compliance with Pydantic classes
-
-    See https://github.com/samuelcolvin/pydantic/issues/380#issuecomment-594639970
-    """
-
-    # TODO: Handle various cases of implicit units, i.e. NumPy arrays that intend
-    # TODO: Use dtype
-
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate_type
-
-    @classmethod
-    def validate_type(cls, val):
-        try:
-            val = unit.Quantity(val)
-            return val
-        # TODO: Handle other exceptions, like pint.UndefinedUnitError
-        except TypeError as e:
-            raise TypeError from e

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -74,6 +74,21 @@ def custom_quantity_encoder(v):
     return json.dumps(v, cls=QuantityEncoder)
 
 
+def json_loader(data):
+    data = json.loads(data)
+    for key, val in data.items():
+        try:
+            v = json.loads(val)
+            if "unit" in v:
+                unit_ = unit(v["unit"])
+                val = v["val"]
+                data[key] = unit_ * val
+        except Exception as e:
+            # TODO: Figure out what cases to catch here
+            raise e
+    return data
+
+
 class _ArrayQuantityMeta(type):
     def __getitem__(self, t):
         return type("ArrayQuantity", (ArrayQuantity,), {"__unit__": t})
@@ -123,6 +138,7 @@ class DefaultModel(BaseModel):
         json_encoders = {
             unit.Quantity: custom_quantity_encoder,
         }
+        json_loads = json_loader
 
 
 class UnitArrayMeta(type):

--- a/openff/system/utils.py
+++ b/openff/system/utils.py
@@ -10,7 +10,6 @@ from simtk import openmm
 from simtk import unit as omm_unit
 
 from openff.system import unit
-from openff.system.types import UnitArray
 
 
 def pint_to_simtk(quantity):
@@ -33,14 +32,14 @@ def simtk_to_pint(simtk_quantity):
     target_unit = unit_to_string(openmm_unit)
     target_unit = unit.Unit(target_unit)
 
-    return UnitArray(openmm_value, units=target_unit)
+    return openmm_value * target_unit
 
 
 def unwrap_list_of_pint_quantities(quantities):
     assert set(val.units for val in quantities) == {quantities[0].units}
     parsed_unit = quantities[0].units
     vals = [val.magnitude for val in quantities]
-    return UnitArray(vals, units=parsed_unit)
+    return vals * parsed_unit
 
 
 def compare_sympy_expr(expr1, expr2):

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ per-file-ignores =
     openff/system/tests/test_stubs.py:F401
     openff/system/tests/test_typing.py:F401
     openff/system/tests/test_matrix_representations.py:F401
+    openff/system/tests/test_types.py:F821
 
 [isort]
 multi_line_output=3


### PR DESCRIPTION
### Description
This PR beings to implement some models for `pint.Quantity` wrappers that play well with pydantic models.


### Todos
  - [x] `ArrayQuantity`
  - [x] Deserialization
  - [x] Remove old code
  - [ ] Enforce explicitness of units in existing models? (a.k.a. revert most of #65)