### PR TITLE
Add support for unyt data in unit models

### DIFF
--- a/devtools/conda-envs/intermol_env.yaml
+++ b/devtools/conda-envs/intermol_env.yaml
@@ -20,3 +20,4 @@ dependencies:
   - codecov
   - intermol
   - gromacs
+  - unyt

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,3 +19,4 @@ dependencies:
   - codecov
   - nbval
   - mypy
+  - unyt

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -2,6 +2,7 @@ import json
 
 import numpy as np
 import pytest
+import unyt
 from pydantic import ValidationError
 from simtk import unit as omm_unit
 
@@ -101,6 +102,23 @@ class TestQuantityTypes:
             ValueError, match=r"Could not validate data of type .*[bool|int].*"
         ):
             Model(a=val)
+
+    def test_unyt_quantities(self):
+        class Subject(DefaultModel):
+            age: FloatQuantity["year"]
+            height: FloatQuantity["centimeter"]
+            doses: ArrayQuantity["milligram"]
+
+        subject = Subject(
+            age=20.0,
+            height=170.0 * unyt.cm,
+            doses=[2, 1, 1] * unyt.gram,
+        )
+
+        # Ensure unyt scalars (unyt.unyt_quantity) are stored as floats
+        assert type(subject.age.m) == float
+        assert type(subject.height.m) == float
+        assert type(subject.doses.m) == np.ndarray
 
     def test_float_and_quantity_type(self):
         class MixedModel(DefaultModel):

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,3 +82,6 @@ ignore_missing_imports = True
 
 [mypy-jax]
 ignore_missing_imports = True
+
+[mypy-unyt]
+ignore_missing_imports = True


### PR DESCRIPTION
### Description
This PR adds support for `unyt`, at least in the context of parsing `unyt` data into the existing unit models. Internally, the thin wrapper around `pint` and its associated unit registry are unchanged.

I found a minor complication resulting from `unyt.unyt_quantity` being a subclass of `unyt.unyt_array`, which is that `.to_pint()` gives an array-like `pint.Quantity` when you’d expect something float-like. I’m able to hack this without much effort in pint. I don’t expect this to be a major issue, but it will be hard to tell with only unit tests.

```python3
In [32]: val
Out[32]: unyt_quantity(4, 'nm')

In [33]: val.to_pint()
Out[33]: array(4) <Unit('nanometer')>

In [34]: _from_unyt_quantity(val)
Out[34]: 4.0 <Unit('nanometer')>