### PR TITLE
Pin mypy to 0.790

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -15,5 +15,5 @@ dependencies:
   - pytest-cov
   - codecov
   - nbval
-  - mypy
+  - mypy =0.790
   - unyt


### PR DESCRIPTION
`mypy` was recently bumped to 0.800, which introduced several changes. This pins to the old version until I can look into the changes.