### PR TITLE
Add requires_package

### DIFF
--- a/openff/system/components/potentials.py
+++ b/openff/system/components/potentials.py
@@ -2,11 +2,11 @@ from typing import Dict, List, Set, Union
 
 from openff.toolkit.topology.topology import Topology
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
-from openff.toolkit.utils.utils import requires_package
 from pydantic import validator
 
 from openff.system.exceptions import InvalidExpressionError
 from openff.system.types import ArrayQuantity, DefaultModel, FloatQuantity
+from openff.system.utils import requires_package
 
 
 class Potential(DefaultModel):

--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -34,7 +34,7 @@ class ToolkitTopologyConformersNotFoundError(Exception):
             msg += f"The molecule lacking a conformer is {self.mol}"
 
 
-class MissingDependencyError:
+class MissingDependencyError(BaseException):
     """
     Exception for when an optional dependency is needed but not installed
 

--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -34,18 +34,19 @@ class ToolkitTopologyConformersNotFoundError(Exception):
             msg += f"The molecule lacking a conformer is {self.mol}"
 
 
-class JAXNotInstalledError(ImportError):
+class MissingDependencyError:
     """
-    Exception for when JAX is called, but not installed
+    Exception for when an optional dependency is needed but not installed
+
     """
 
-    def __str__(self):
-        msg = (
-            "\nThis function requires JAX, which was not found to be installed."
-            "\nInstall it with `conda install jax -c conda-forge` or"
-            "\n`pip install --upgrade pip && pip install --upgrade jax jaxlib`."
+    def __init__(self, package_name):
+        self.msg = (
+            f"Missing dependency {package_name}. Try installing it "
+            f"with\n\n$ conda install {package_name} -c conda-forge"
         )
-        return msg
+
+        super().__init__(self.msg)
 
 
 class InvalidBoxError(TypeError):

--- a/openff/system/tests/test_matrix_representations.py
+++ b/openff/system/tests/test_matrix_representations.py
@@ -2,10 +2,11 @@ import numpy as np
 import pytest
 
 from openff.system.tests.base_test import BaseTest
-from openff.system.utils import get_test_file_path, requires_package
+from openff.system.tests.utils import requires_pkg
+from openff.system.utils import get_test_file_path
 
 
-@requires_package
+@requires_pkg("jax")
 class TestMatrixRepresentations(BaseTest):
     @pytest.mark.parametrize(
         "handler_name,n_ff_terms,n_sys_terms",

--- a/openff/system/tests/test_matrix_representations.py
+++ b/openff/system/tests/test_matrix_representations.py
@@ -2,11 +2,11 @@ import numpy as np
 import pytest
 
 from openff.system.tests.base_test import BaseTest
-from openff.system.utils import get_test_file_path, jax_available
+from openff.system.utils import get_test_file_path, requires_package
 
 
+@requires_package
 class TestMatrixRepresentations(BaseTest):
-    @pytest.mark.skipif(not jax_available, reason="Requires JAX")
     @pytest.mark.parametrize(
         "handler_name,n_ff_terms,n_sys_terms",
         [("vdW", 10, 72), ("Bonds", 8, 64), ("Angles", 6, 104)],

--- a/openff/system/tests/test_utils.py
+++ b/openff/system/tests/test_utils.py
@@ -76,3 +76,21 @@ class TestOpenMM(BaseTest):
         # assert partial_charges.units == unit.elementary_charge
         assert isinstance(partial_charges, list)
         assert np.allclose(partial_charges, np.zeros(4))  # .magnitude
+
+
+def test_requires_package():
+    """Test the @requires_package decorator"""
+    from openff.toolkit.utils.utils import MissingDependencyError, requires_package
+
+    @requires_package("numpy")
+    def fn_installed():
+        pass
+
+    fn_installed()
+
+    @requires_package("foobar")
+    def fn_missing():
+        pass
+
+    with pytest.raises(MissingDependencyError, match="foobar"):
+        fn_missing()

--- a/openff/system/tests/test_utils.py
+++ b/openff/system/tests/test_utils.py
@@ -4,11 +4,13 @@ from openff.toolkit.typing.engines.smirnoff import ForceField
 from simtk import unit as simtk_unit
 
 from openff.system import unit
+from openff.system.exceptions import MissingDependencyError
 from openff.system.tests.base_test import BaseTest
 from openff.system.utils import (
     compare_forcefields,
     get_partial_charges_from_openmm_system,
     pint_to_simtk,
+    requires_package,
     simtk_to_pint,
     unwrap_list_of_pint_quantities,
 )
@@ -80,9 +82,8 @@ class TestOpenMM(BaseTest):
 
 def test_requires_package():
     """Test the @requires_package decorator"""
-    from openff.toolkit.utils.utils import MissingDependencyError, requires_package
 
-    @requires_package("numpy")
+    @requires_package("re")
     def fn_installed():
         pass
 

--- a/openff/system/tests/utils.py
+++ b/openff/system/tests/utils.py
@@ -1,8 +1,40 @@
+import importlib
+
 import numpy as np
+import pytest
 from openff.toolkit.topology import Molecule, Topology
 from simtk import unit
 
 from openff.system.exceptions import InterMolEnergyComparisonError
+
+
+def requires_pkg(pkg_name, reason=None):
+    """
+    Helper function to generate a skipif decorator for any package.
+
+    Parameters
+    ----------
+    pkg_name : str
+        The name of the package that is required for a test(s)
+    reason : str, optional
+        Explanation of why the skipped it to be tested
+
+    Returns
+    -------
+    requires_pkg : _pytest.mark.structures.MarkDecorator
+        A pytest decorator that will skip tests if the package is not available
+    """
+    if not reason:
+        reason = f"Package {pkg_name} is required, but was not found."
+    try:
+        importlib.import_module(pkg_name)
+        mark = pytest.mark.skipif(
+            False,
+            reason="blank decorator, should never be printed",
+        )
+    except ImportError:
+        mark = pytest.mark.skip(reason=reason)
+    return mark
 
 
 def top_from_smiles(

--- a/openff/system/utils.py
+++ b/openff/system/utils.py
@@ -1,3 +1,4 @@
+import functools
 import pathlib
 from collections import OrderedDict
 from typing import List
@@ -9,6 +10,7 @@ from simtk import openmm
 from simtk import unit as omm_unit
 
 from openff.system import unit
+from openff.system.exceptions import MissingDependencyError
 
 
 def pint_to_simtk(quantity):
@@ -35,7 +37,7 @@ def simtk_to_pint(simtk_quantity):
 
 
 def unwrap_list_of_pint_quantities(quantities):
-    assert set(val.units for val in quantities) == {quantities[0].units}
+    assert {val.units for val in quantities} == {quantities[0].units}
     parsed_unit = quantities[0].units
     vals = [val.magnitude for val in quantities]
     return vals * parsed_unit
@@ -90,10 +92,21 @@ def compare_forcefields(ff1, ff2):
     assert ff1 == ff2
 
 
-try:
-    import jax
+def requires_package(package_name):
+    def inner_decorator(function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            import importlib
 
-    jax.__version__
-    jax_available = True
-except ImportError:
-    jax_available = False
+            try:
+                importlib.import_module(package_name)
+            except ImportError:
+                raise MissingDependencyError(package_name)
+            except Exception as e:
+                raise e
+
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return inner_decorator


### PR DESCRIPTION
### Description
I'm about to try using OpenFF Recharge for handling BCCs, and I'd like that to be an optional dependency while it's still in an early stage. This PR copies the `requires_package` function from the toolkit for that purpose and surely many future uses. It also removes the old JAX checking.

### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
