### PR TITLE
Drop Python 3.6 from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/openff/system/tests/test_interop/test_internal_writers.py
+++ b/openff/system/tests/test_interop/test_internal_writers.py
@@ -74,8 +74,8 @@ def test_internal_gromacs_writers(mol):
 
 def compare_gro_files(file1: str, file2: str):
     """Helper function to compare the contents of two GRO files"""
-    with open(file1, "r") as f1:
-        with open(file2, "r") as f2:
+    with open(file1) as f1:
+        with open(file2) as f2:
             # Ignore first two lines and last line
             for line1, line2 in zip(f1.readlines()[2:-1], f2.readlines()[2:-1]):
                 # Ignore atom type column

--- a/openff/system/utils.py
+++ b/openff/system/utils.py
@@ -35,7 +35,7 @@ def simtk_to_pint(simtk_quantity):
 
 
 def unwrap_list_of_pint_quantities(quantities):
-    assert set(val.units for val in quantities) == {quantities[0].units}
+    assert {val.units for val in quantities} == {quantities[0].units}
     parsed_unit = quantities[0].units
     vals = [val.magnitude for val in quantities]
     return vals * parsed_unit


### PR DESCRIPTION
### Description
Python 3.6 has been out of the NEP 29 recommendations for over a year now. It's not causing any problems, but I'd like to remove it before it does. This also runs `pyupgrade --py37-plus`.

### Checklist
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
