### PR TITLE
Update exceptions

### DIFF
--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -6,6 +6,7 @@ from openff.toolkit.topology.topology import Topology
 from pydantic import validator
 
 from openff.system.components.potentials import PotentialHandler
+from openff.system.exceptions import InvalidBoxError, MissingPositionsError
 from openff.system.interop.openmm import to_openmm
 from openff.system.interop.parmed import to_parmed
 from openff.system.types import ArrayQuantity, DefaultModel
@@ -34,13 +35,13 @@ class System(DefaultModel):
             val = val * np.eye(3)
             return val
         else:
-            raise ValueError  # InvalidBoxError
+            raise InvalidBoxError
 
     def to_gro(self, file_path: Union[Path, str], writer="parmed"):
         """Export this system to a .gro file using ParmEd"""
 
         if self.positions is None:
-            raise Exception
+            raise MissingPositionsError
 
         # TODO: Enum-style class for handling writer arg?
         if writer == "parmed":
@@ -67,7 +68,7 @@ class System(DefaultModel):
 
     def to_openmm(self):
         """Export this sytem to an OpenMM System"""
-        assert self._check_nonbonded_compatibility()
+        self._check_nonbonded_compatibility()
         return to_openmm(self)
 
     def to_parmed(self):

--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -90,3 +90,22 @@ class System(DefaultModel):
 
         nonbonded_ = self._get_nonbonded_methods()
         return check_nonbonded_compatibility(nonbonded_)
+
+    def __getitem__(self, item: str):
+        """Syntax sugar for looking up potential handlers or other components"""
+        if type(item) != str:
+            raise LookupError(
+                "Only str arguments can be currently be used for lookups.\n"
+                f"Found item {item} of type {type(item)}"
+            )
+        if item == "positions":
+            return self.positions
+        elif item in {"box", "box_vectors"}:
+            return self.box
+        elif item in self.handlers:
+            return self.handlers[item]
+        else:
+            raise LookupError(
+                f"Could not find component {item}. This object has the following "
+                f"potential handlers registered:\n\t{[*self.handlers.keys()]}"
+            )

--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -49,7 +49,7 @@ class MissingDependencyError(BaseException):
         super().__init__(self.msg)
 
 
-class InvalidBoxError(TypeError):
+class InvalidBoxError(ValueError):
     """
     Generic exception for errors reading box data
     """
@@ -117,4 +117,41 @@ class MissingPositionsError(BaseException):
 class MissingParametersError(BaseException):
     """
     Exception for when parameters are needed but missing
+    """
+
+
+class MissingUnitError(ValueError):
+    """
+    Exception for data missing a unit tag
+    """
+
+
+class UnitValidationError(ValueError):
+    """
+    Exception for bad behavior when validating unit-tagged data
+    """
+
+
+class NonbondedCompatibilityError(BaseException):
+    """
+    Exception for unsupported combination of nonbonded methods
+    """
+
+
+class MissingNonbondedCompatibilityError(BaseException):
+    """
+    Exception for uncovered combination of nonbonded methods
+    """
+
+
+class InternalInconsistencyError(BaseException):
+    """
+    Fallback exception for bad behavior. These should not be reached but
+    are raised to safeguard against problematic edge cases silently passing.
+    """
+
+
+class GMXRunError(BaseException):
+    """
+    Exception for when a GROMACS subprocess fails.
     """

--- a/openff/system/interop/compatibility/nonbonded.py
+++ b/openff/system/interop/compatibility/nonbonded.py
@@ -34,7 +34,9 @@ def check_nonbonded_compatibility(methods):
     """Check nonbonded methods against known allowed and disallowed
     combinations of nonbonded methods"""
     if methods["electrostatics_method"] in {"reaction-field"}:
-        raise NotImplementedError("Electrostatics method not supported")
+        raise NonbondedCompatibilityError(
+            "Electrostatics method reaction-field is not supported"
+        )
     if methods in ALLOWED:
         return
     elif methods in DISALLOWED:

--- a/openff/system/interop/compatibility/nonbonded.py
+++ b/openff/system/interop/compatibility/nonbonded.py
@@ -1,3 +1,8 @@
+from openff.system.exceptions import (
+    MissingNonbondedCompatibilityError,
+    NonbondedCompatibilityError,
+)
+
 ALLOWED = [
     {
         "electrostatics_method": "PME",
@@ -5,7 +10,12 @@ ALLOWED = [
         "periodic_topology": True,
     },
     {
-        "electrostatics_method": "Coulomb",
+        "electrostatics_method": "PME",
+        "vdw_method": "cutoff",
+        "periodic_topology": False,
+    },
+    {
+        "electrostatics_method": "cutoff",
         "vdw_method": "cutoff",
         "periodic_topology": True,
     },
@@ -13,7 +23,7 @@ ALLOWED = [
 
 DISALLOWED = [
     {
-        "electrostatics_method": "PME",
+        "electrostatics_method": "Coulomb",
         "vdw_method": "cutoff",
         "periodic_topology": False,
     },
@@ -26,8 +36,8 @@ def check_nonbonded_compatibility(methods):
     if methods["electrostatics_method"] in {"reaction-field"}:
         raise NotImplementedError("Electrostatics method not supported")
     if methods in ALLOWED:
-        return True
+        return
     elif methods in DISALLOWED:
-        return False
+        raise NonbondedCompatibilityError(methods)
     else:
-        raise Exception
+        raise MissingNonbondedCompatibilityError(methods)

--- a/openff/system/interop/internal.py
+++ b/openff/system/interop/internal.py
@@ -7,6 +7,7 @@ from openff.toolkit.topology import FrozenMolecule, Molecule, Topology
 
 from openff.system import unit
 from openff.system.components.system import System
+from openff.system.exceptions import InternalInconsistencyError
 
 
 def to_gro(openff_sys: System, file_path: Union[Path, str]):
@@ -274,7 +275,7 @@ def _write_bonds(top_file: IO, openff_sys: System, ref_mol: FrozenMolecule):
         if indices_as_str in bond_handler.slot_map.keys():
             key = bond_handler.slot_map[indices_as_str]
         else:
-            raise Exception("probably should have found parameters here ...")
+            raise InternalInconsistencyError("Failed to find parameters")
 
         # "reference" indices
         ref_indices = [idx - offset for idx in indices]
@@ -316,7 +317,7 @@ def _write_angles(top_file: IO, openff_sys: System, ref_mol: FrozenMolecule):
         if indices_as_str in angle_handler.slot_map.keys():
             key = angle_handler.slot_map[indices_as_str]
         else:
-            raise Exception
+            raise InternalInconsistencyError("Failed to find parameters")
 
         # "reference" indices
         ref_indices = [idx - offset for idx in indices]

--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -1,7 +1,10 @@
 from simtk import openmm, unit
 
 from openff.system import unit as off_unit
-from openff.system.exceptions import UnsupportedCutoffMethodError
+from openff.system.exceptions import (
+    InternalInconsistencyError,
+    UnsupportedCutoffMethodError,
+)
 from openff.system.interop.parmed import _lj_params_from_potential
 
 kcal_mol = unit.kilocalorie_per_mole
@@ -171,7 +174,7 @@ def _process_improper_torsion_forces(openff_sys, openmm_sys):
             break
     else:
         # TODO: Support case of no propers but some impropers?
-        raise Exception
+        raise InternalInconsistencyError
 
     improper_torsion_handler = openff_sys.handlers["ImproperTorsions"]
 

--- a/openff/system/tests/energy_tests/gromacs.py
+++ b/openff/system/tests/energy_tests/gromacs.py
@@ -8,6 +8,7 @@ from openff.toolkit.utils.utils import temporary_cd
 from simtk import unit as omm_unit
 
 from openff.system.components.system import System
+from openff.system.exceptions import GMXRunError
 from openff.system.tests.energy_tests.report import EnergyReport
 from openff.system.utils import get_test_file_path
 
@@ -63,8 +64,7 @@ def run_gmx_energy(
     _, err = grompp.communicate()
 
     if grompp.returncode:
-        print(err)
-        raise Exception
+        raise GMXRunError(err)
 
     mdrun_cmd = "gmx mdrun -deffnm out"
 
@@ -79,7 +79,7 @@ def run_gmx_energy(
     _, err = mdrun.communicate()
 
     if mdrun.returncode:
-        raise Exception
+        raise GMXRunError(err)
 
     energy_cmd = "gmx energy -f out.edr -o out.xvg"
     stdin = " ".join(map(str, range(1, 20))) + " 0 "
@@ -96,7 +96,7 @@ def run_gmx_energy(
     _, err = energy.communicate(input=stdin)
 
     if energy.returncode:
-        raise Exception
+        raise GMXRunError(err)
 
     return _parse_gmx_energy("out.xvg", electrostatics=electrostatics)
 

--- a/openff/system/tests/test_interop/test_compatibility.py
+++ b/openff/system/tests/test_interop/test_compatibility.py
@@ -3,6 +3,7 @@ import pytest
 from openff.toolkit.topology import Molecule
 from simtk import unit as omm_unit
 
+from openff.system.exceptions import MissingPositionsError
 from openff.system.stubs import ForceField
 
 
@@ -19,9 +20,6 @@ def test_nonbonded_compatibility():
 
     off_sys = parsley.create_openff_system(top)
 
-    with pytest.raises(AssertionError):
-        off_sys.to_openmm()
-
     off_sys.box = box
 
     off_sys.handlers["Electrostatics"].method = "reaction-field"
@@ -33,7 +31,7 @@ def test_nonbonded_compatibility():
 
     off_sys.handlers["Electrostatics"].method = "PME"
 
-    with pytest.raises(Exception):
+    with pytest.raises(MissingPositionsError):
         off_sys.to_gro("out.gro", writer="internal")
 
     off_sys.positions = positions

--- a/openff/system/tests/test_system.py
+++ b/openff/system/tests/test_system.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+from openff.toolkit.topology import Molecule
+
+from openff.system import unit
+from openff.system.stubs import ForceField
+
+
+def test_getitem():
+    """Test behavior of System.__getitem__"""
+    mol = Molecule.from_smiles("CCO")
+    parsley = ForceField("openff-1.0.0.offxml")
+    out = parsley.create_openff_system(mol.to_topology())
+
+    out.box = [4, 4, 4]
+
+    assert not out.positions
+    np.testing.assert_equal(out["box"].m, (4 * np.eye(3) * unit.nanometer).m)
+    np.testing.assert_equal(out["box"].m, out["box_vectors"].m)
+
+    assert out["Bonds"] == out.handlers["Bonds"]
+
+    with pytest.raises(LookupError, match="Only str"):
+        out[1]
+
+    with pytest.raises(LookupError, match="Could not find"):
+        out["CMAPs"]

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from simtk import unit as omm_unit
 
 from openff.system import unit
+from openff.system.exceptions import UnitValidationError
 from openff.system.types import ArrayQuantity, DefaultModel, FloatQuantity
 
 
@@ -53,7 +54,8 @@ class TestQuantityTypes:
             a: FloatQuantity["atomic_mass_constant"]
 
         with pytest.raises(
-            ValueError, match=r"Could not validate data of type .*[bool|list].*"
+            ValidationError,
+            match=r"Could not validate data of type .*[bool|list].*",
         ):
             Model(a=val)
 
@@ -102,7 +104,7 @@ class TestQuantityTypes:
             a: ArrayQuantity["atomic_mass_constant"]
 
         with pytest.raises(
-            ValueError, match=r"Could not validate data of type .*[bool|int].*"
+            ValidationError, match=r"Could not validate data of type .*[bool|int].*"
         ):
             Model(a=val)
 
@@ -214,5 +216,5 @@ def test_from_omm_quantity():
     from_array = _from_omm_quantity(np.asarray([1, 0]) * omm_unit.second)
     assert all(from_array == from_list)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(UnitValidationError):
         _from_omm_quantity(True * omm_unit.femtosecond)


### PR DESCRIPTION
### Description
This PR makes a few more custom exceptions and replaces several calls to built-in exceptions. I'm also sneaking in a `__getitem__` override to make lookups like `out.handlers['Bonds']` one step shorter.

### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
