### PR TITLE
Report Ryckaert-Bellemans torsions in GROMACS energy driver

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,3 +23,4 @@ dependencies:
   - gromacs
   - lammps
   - mbuild
+  - foyer

--- a/openff/system/tests/energy_tests/gromacs.py
+++ b/openff/system/tests/energy_tests/gromacs.py
@@ -116,6 +116,7 @@ def _get_gmx_energy_nonbonded(gmx_energies: Dict):
 def _parse_gmx_energy(xvg_path, electrostatics=True):
     energies, _ = _group_energy_terms(xvg_path)
 
+    # TODO: Better way of filling in missing fields
     # GROMACS may not populate all keys
     for required_key in ["Bond", "Angle", "Proper Dih."]:
         if required_key not in energies:
@@ -147,6 +148,9 @@ def _parse_gmx_energy(xvg_path, electrostatics=True):
             "Torsion": energies["Proper Dih."],
         }
     )
+
+    if "Ryckaert-Bell." in energies:
+        report.energies["Torsion"] += energies["Ryckaert-Bell."]
 
     if electrostatics is True:
         report.energies.update(

--- a/openff/system/tests/energy_tests/utils.py
+++ b/openff/system/tests/energy_tests/utils.py
@@ -1,3 +1,7 @@
+import mbuild as mb
+from openff.toolkit.topology import Molecule
+from simtk import unit as omm_unit
+
 from openff.system.tests.energy_tests.report import EnergyReport
 
 
@@ -34,3 +38,21 @@ def compare_openmm(
 ):
 
     report1.compare(report2)
+
+
+def offmol_to_compound(off_mol: Molecule) -> mb.Compound:
+
+    assert len(off_mol.conformers) > 0
+
+    comp = mb.Compound()
+
+    for a in off_mol.atoms:
+        atom_comp = mb.Particle(name=a.element.symbol)
+        comp.add(atom_comp, label=a.name)
+
+    for b in off_mol.bonds:
+        comp.add_bond((comp[b.atom1_index], comp[b.atom2_index]))
+
+    comp.xyz = off_mol.conformers[0].value_in_unit(omm_unit.nanometer)
+
+    return comp

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,3 +93,6 @@ ignore_missing_imports = True
 
 [mypy-mbuild]
 ignore_missing_imports = True
+
+[mypy-foyer]
+ignore_missing_imports = True


### PR DESCRIPTION
### Description
While experimenting with Foyer, I noticed that Ryckaert-Bellemans torsions were not processed by the GROMACS energy parser. This is because GROMACS reports it in a separate column as other dihedrals. This PR fixes that.

@j-wags contributed significantly to the development of this code

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
