### PR TITLE
Refactor keys in topology/potential mappings

### DIFF
--- a/examples/optimize-with-jax.ipynb
+++ b/examples/optimize-with-jax.ipynb
@@ -314,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/examples/parameter_replacement.ipynb
+++ b/examples/parameter_replacement.ipynb
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/examples/smirnoff_argon.ipynb
+++ b/examples/smirnoff_argon.ipynb
@@ -11,7 +11,8 @@
     "from openff.toolkit.topology import Molecule, Topology\n",
     "\n",
     "from openff.system.stubs import ForceField\n",
-    "from openff.system.utils import get_test_file_path"
+    "from openff.system.utils import get_test_file_path\n",
+    "from openff.system.models import PotentialKey, TopologyKey"
    ]
   },
   {
@@ -98,8 +99,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Look at this contents of this Potential objects\n",
-    "vdw.potentials[\"[#18:1]\"]"
+    "# Look at this contents of this Potential object\n",
+    "potential_key = PotentialKey(id=\"[#18:1]\")\n",
+    "vdw.potentials[potential_key]"
    ]
   },
   {
@@ -109,7 +111,7 @@
    "outputs": [],
    "source": [
     "# Further, look at the particular value of one of its parameters\n",
-    "vdw.potentials[\"[#18:1]\"].parameters[\"sigma\"]"
+    "vdw.potentials[potential_key].parameters[\"sigma\"]"
    ]
   },
   {
@@ -121,9 +123,10 @@
     "# Look up, from the highest-level object, this same data, using the\n",
     "# SMIRKS pattern as a key connecting the topological data to the\n",
     "# parametrized data\n",
-    "off_sys.handlers[\"vdW\"].potentials[off_sys.handlers[\"vdW\"].slot_map[\"(0,)\"]].parameters[\n",
-    "    \"sigma\"\n",
-    "]"
+    "topology_key = TopologyKey(atom_indices=(0,))\n",
+    "off_sys.handlers[\"vdW\"].potentials[\n",
+    "    off_sys.handlers[\"vdW\"].slot_map[topology_key]\n",
+    "].parameters[\"sigma\"]"
    ]
   }
  ],
@@ -143,7 +146,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/examples/smirnoff_ethanol.ipynb
+++ b/examples/smirnoff_ethanol.ipynb
@@ -11,7 +11,8 @@
     "from openff.toolkit.topology import Molecule, Topology\n",
     "\n",
     "from openff.system.stubs import ForceField\n",
-    "from openff.system.utils import get_test_file_path"
+    "from openff.system.utils import get_test_file_path\n",
+    "from openff.system.models import PotentialKey, TopologyKey"
    ]
   },
   {
@@ -96,7 +97,8 @@
    "outputs": [],
    "source": [
     "# Look at this contents of one of the Potential objects\n",
-    "bonds.potentials[\"[#6X4:1]-[#1:2]\"]"
+    "potential_key = PotentialKey(id=\"[#6X4:1]-[#1:2]\")\n",
+    "bonds.potentials[potential_key]"
    ]
   },
   {
@@ -106,7 +108,7 @@
    "outputs": [],
    "source": [
     "# Further, look at the particular value of one of its parameters\n",
-    "bonds.potentials[\"[#6X4:1]-[#1:2]\"].parameters[\"k\"]"
+    "bonds.potentials[potential_key].parameters[\"k\"]"
    ]
   },
   {
@@ -118,8 +120,9 @@
     "# Look up, from the highest-level object, this same data, using the\n",
     "# SMIRKS pattern as a key connecting the topological data to the\n",
     "# parametrized data\n",
+    "topology_key = TopologyKey(atom_indices=(1, 7))\n",
     "sys_out.handlers[\"Bonds\"].potentials[\n",
-    "    sys_out.handlers[\"Bonds\"].slot_map[\"(1, 7)\"]\n",
+    "    sys_out.handlers[\"Bonds\"].slot_map[topology_key]\n",
     "].parameters[\"k\"]"
    ]
   }

--- a/openff/system/components/potentials.py
+++ b/openff/system/components/potentials.py
@@ -5,7 +5,8 @@ from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
 from pydantic import validator
 
 from openff.system.exceptions import InvalidExpressionError
-from openff.system.types import ArrayQuantity, DefaultModel, FloatQuantity
+from openff.system.models import DefaultModel, PotentialKey, TopologyKey
+from openff.system.types import ArrayQuantity, FloatQuantity
 from openff.system.utils import requires_package
 
 
@@ -31,8 +32,8 @@ class PotentialHandler(DefaultModel):
     name: str
     expression: str
     independent_variables: Union[str, Set[str]]
-    slot_map: Dict[str, str] = dict()
-    potentials: Dict[str, Potential] = dict()
+    slot_map: Dict[TopologyKey, PotentialKey] = dict()
+    potentials: Dict[PotentialKey, Potential] = dict()
 
     # Pydantic silently casts some types (int, float, Decimal) to str
     # in models that expect str; this may be updates, see #1098

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -381,8 +381,9 @@ class SMIRNOFFLibraryChargeHandler(  # type: ignore[misc]
     ) -> None:
         matches = parameter_handler.find_matches(topology)
         for key, val in matches.items():
-            top_key = TopologyKey(atom_indices=(key,))
-            self.slot_map[top_key] = val.parameter_type.smirks
+            top_key = TopologyKey(atom_indices=key)
+            pot_key = PotentialKey(id=val.parameter_type.smirks)
+            self.slot_map[top_key] = pot_key
 
     def store_potentials(self, parameter_handler: LibraryChargeHandler) -> None:
         if self.potentials:
@@ -413,8 +414,9 @@ class SMIRNOFFChargeIncrementHandler(  # type: ignore[misc]
     ) -> None:
         matches = parameter_handler.find_matches(topology)
         for key, val in matches.items():
-            key = str(key)
-            self.slot_map[key] = val.parameter_type.smirks
+            top_key = TopologyKey(atom_indices=key)
+            pot_key = PotentialKey(id=val.parameter_type.smirks)
+            self.slot_map[top_key] = pot_key
 
     def store_potentials(self, parameter_handler: ChargeIncrementModelHandler) -> None:
         if self.potentials:

--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -13,7 +13,8 @@ from openff.system.exceptions import (
 )
 from openff.system.interop.openmm import to_openmm
 from openff.system.interop.parmed import to_parmed
-from openff.system.types import ArrayQuantity, DefaultModel
+from openff.system.models import DefaultModel
+from openff.system.types import ArrayQuantity
 
 
 class System(DefaultModel):

--- a/openff/system/interop/internal/lammps.py
+++ b/openff/system/interop/internal/lammps.py
@@ -6,6 +6,7 @@ from simtk import unit as omm_unit
 
 from openff.system import unit
 from openff.system.components.system import System
+from openff.system.models import TopologyKey
 
 
 def to_lammps(openff_sys: System, file_path: Union[Path, str]):
@@ -88,7 +89,7 @@ def to_lammps(openff_sys: System, file_path: Union[Path, str]):
 
         for atom_type_idx, smirks in atom_type_map.items():
             # Find just one topology atom matching this SMIRKS by vdW
-            matched_atom_idx = eval(slot_map_inv[smirks])[0]
+            matched_atom_idx = slot_map_inv[smirks].atom_indices[0]
             matched_atom = openff_sys.topology.atom(matched_atom_idx)  # type: ignore
             mass = matched_atom.atom.mass.value_in_unit(omm_unit.dalton)
 
@@ -191,10 +192,11 @@ def _write_atoms(lmp_file: IO, openff_sys: System, atom_type_map: Dict):
 
         molecule_idx = molecule_map_inv[atom.topology_molecule]
 
-        vdw_smirks = vdw_hander.slot_map[str((atom_idx,))]
+        vdw_smirks = vdw_hander.slot_map[TopologyKey(atom_indices=(atom_idx,))].id
         atom_type = atom_type_map_inv[vdw_smirks]
 
-        charge = electrostatics_handler.charges[str((atom_idx,))].magnitude  # type: ignore
+        top_key = TopologyKey(atom_indices=(atom_idx,))
+        charge = electrostatics_handler.charges[top_key].magnitude  # type: ignore[attr-defined]
         pos = openff_sys.positions[atom_idx].to(unit.angstrom).magnitude
         lmp_file.write(
             "{:d}\t{:d}\t{:d}\t{:.8g}\t{:.8g}\t{:.8g}\t{:.8g}\n".format(

--- a/openff/system/interop/internal/lammps.py
+++ b/openff/system/interop/internal/lammps.py
@@ -192,8 +192,9 @@ def _write_atoms(lmp_file: IO, openff_sys: System, atom_type_map: Dict):
 
         molecule_idx = molecule_map_inv[atom.topology_molecule]
 
-        vdw_smirks = vdw_hander.slot_map[TopologyKey(atom_indices=(atom_idx,))].id
-        atom_type = atom_type_map_inv[vdw_smirks]
+        top_key = TopologyKey(atom_indices=(atom_idx,))
+        pot_key = vdw_hander.slot_map[top_key]
+        atom_type = atom_type_map_inv[pot_key]
 
         top_key = TopologyKey(atom_indices=(atom_idx,))
         charge = electrostatics_handler.charges[top_key].magnitude  # type: ignore[attr-defined]
@@ -222,8 +223,9 @@ def _write_bonds(lmp_file: IO, openff_sys: System):
     for bond_idx, bond in enumerate(openff_sys.topology.topology_bonds):  # type: ignore[union-attr]
         # These are "topology indices"
         indices = tuple(sorted(a.topology_atom_index for a in bond.atoms))
-        smirks = bond_handler.slot_map[str(indices)]
-        bond_type = bond_type_map_inv[smirks]
+        top_key = TopologyKey(atom_indices=indices)
+        pot_key = bond_handler.slot_map[top_key]
+        bond_type = bond_type_map_inv[pot_key]
 
         lmp_file.write(
             "{:d}\t{:d}\t{:d}\t{:d}\n".format(
@@ -246,8 +248,9 @@ def _write_angles(lmp_file: IO, openff_sys: System):
     for angle_idx, angle in enumerate(openff_sys.topology.angles):  # type: ignore[union-attr]
         # These are "topology indices"
         indices = tuple(a.topology_atom_index for a in angle)
-        smirks = angle_handler.slot_map[str(tuple(indices))]
-        angle_type = angle_type_map_inv[smirks]
+        top_key = TopologyKey(atom_indices=indices)
+        pot_key = angle_handler.slot_map[top_key]
+        angle_type = angle_type_map_inv[pot_key]
 
         lmp_file.write(
             "{:d}\t{:d}\t{:d}\t{:d}\t{:d}\n".format(

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -4,6 +4,7 @@ import numpy as np
 import parmed as pmd
 
 from openff.system import unit
+from openff.system.models import TopologyKey
 
 kcal_mol = unit.Unit("kilocalories / mol")
 kcal_mol_a2 = unit.Unit("kilocalories / mol / angstrom ** 2")
@@ -38,16 +39,16 @@ def to_parmed(off_system: Any) -> pmd.Structure:
     if "Bonds" in off_system.handlers.keys():
         bond_handler = off_system.handlers["Bonds"]
         bond_map: Dict = dict()
-        for bond_slot, smirks in bond_handler.slot_map.items():
-            idx_1, idx_2 = eval(bond_slot)
+        for top_key, pot_key in bond_handler.slot_map.items():
+            idx_1, idx_2 = top_key.atom_indices
             try:
-                bond_type = bond_map[smirks]
+                bond_type = bond_map[pot_key]
             except KeyError:
-                pot = bond_handler.potentials[smirks]
+                pot = bond_handler.potentials[pot_key]
                 k = pot.parameters["k"].to(kcal_mol_a2).magnitude / 2
                 length = pot.parameters["length"].to(unit.angstrom).magnitude
                 bond_type = pmd.BondType(k=k, req=length)
-                bond_map[smirks] = bond_type
+                bond_map[pot_key] = bond_type
                 del pot, k, length
             if bond_type not in structure.bond_types:
                 structure.bond_types.append(bond_type)
@@ -58,13 +59,13 @@ def to_parmed(off_system: Any) -> pmd.Structure:
                     type=bond_type,
                 )
             )
-            del bond_type, idx_1, idx_2, smirks, bond_slot
+            del bond_type, idx_1, idx_2, pot_key, top_key
 
     if "Angles" in off_system.handlers.keys():
         angle_term = off_system.handlers["Angles"]
-        for angle, smirks in angle_term.slot_map.items():
-            idx_1, idx_2, idx_3 = eval(angle)
-            pot = angle_term.potentials[smirks]
+        for top_key, pot_key in angle_term.slot_map.items():
+            idx_1, idx_2, idx_3 = top_key.atom_indices
+            pot = angle_term.potentials[pot_key]
             # TODO: Look at cost of redundant conversions, to ensure correct units of .m
             k = pot.parameters["k"].to(kcal_mol_rad2).magnitude / 2
             theta = pot.parameters["angle"].to(unit.degree).magnitude
@@ -91,9 +92,9 @@ def to_parmed(off_system: Any) -> pmd.Structure:
     vdw_handler = off_system.handlers["vdW"]
     if "ProperTorsions" in off_system.handlers.keys():
         proper_term = off_system.handlers["ProperTorsions"]
-        for proper, smirks in proper_term.slot_map.items():
-            idx_1, idx_2, idx_3, idx_4 = eval(proper)
-            pot = proper_term.potentials[smirks]
+        for top_key, pot_key in proper_term.slot_map.items():
+            idx_1, idx_2, idx_3, idx_4 = top_key.atom_indices
+            pot = proper_term.potentials[pot_key]
             for n in range(pot.parameters["n_terms"]):
                 k = pot.parameters["k"][n].to(kcal_mol).magnitude
                 periodicity = pot.parameters["periodicity"][n]
@@ -115,8 +116,10 @@ def to_parmed(off_system: Any) -> pmd.Structure:
                     )
                 )
                 structure.dihedral_types.append(dihedral_type)
-                vdw1 = vdw_handler.potentials[vdw_handler.slot_map[str((idx_1,))]]
-                vdw4 = vdw_handler.potentials[vdw_handler.slot_map[str((idx_4,))]]
+                key1 = TopologyKey(atom_indices=(idx_1,))
+                key4 = TopologyKey(atom_indices=(idx_4,))
+                vdw1 = vdw_handler.potentials[vdw_handler.slot_map[key1]]
+                vdw4 = vdw_handler.potentials[vdw_handler.slot_map[key4]]
                 sig1, eps1 = _lj_params_from_potential(vdw1)
                 sig4, eps4 = _lj_params_from_potential(vdw4)
                 sig = (sig1 + sig4) * 0.5
@@ -155,7 +158,8 @@ def to_parmed(off_system: Any) -> pmd.Structure:
 
     vdw_handler = off_system.handlers["vdW"]
     for pmd_idx, pmd_atom in enumerate(structure.atoms):
-        smirks = vdw_handler.slot_map[str((pmd_idx,))]
+        top_key = TopologyKey(atom_indices=(pmd_idx,))
+        smirks = vdw_handler.slot_map[top_key]
         potential = vdw_handler.potentials[smirks]
         element = pmd.periodic_table.Element[pmd_atom.element]
         sigma, epsilon = _lj_params_from_potential(potential)
@@ -174,7 +178,8 @@ def to_parmed(off_system: Any) -> pmd.Structure:
 
     for pmd_idx, pmd_atom in enumerate(structure.atoms):
         if has_electrostatics:
-            partial_charge = electrostatics_handler.charges[str((pmd_idx,))]
+            top_key = TopologyKey(atom_indices=(pmd_idx,))
+            partial_charge = electrostatics_handler.charges[top_key]
             unitless_ = partial_charge.to(unit.elementary_charge).magnitude
             pmd_atom.charge = float(unitless_)
             pmd_atom.atom_type.charge = float(unitless_)

--- a/openff/system/models.py
+++ b/openff/system/models.py
@@ -1,0 +1,42 @@
+from typing import Optional, Sequence
+
+from pydantic import BaseModel, Field
+
+from openff.system import unit
+from openff.system.types import custom_quantity_encoder, json_loader
+
+
+class DefaultModel(BaseModel):
+    class Config:
+        json_encoders = {
+            unit.Quantity: custom_quantity_encoder,
+        }
+        json_loads = json_loader
+        validate_assignment = True
+        arbitrary_types_allowed = True
+
+
+class TopologyKey(DefaultModel):
+    # Should be Tuple[int], see issues #495
+    atom_indices: Sequence[int] = Field(
+        tuple(), description="The indices of the atoms occupied by this interaction"
+    )
+    mult: Optional[int] = Field(
+        None, description="The index of this duplicate interaction"
+    )
+
+    def __hash__(self):
+        return hash((self.atom_indices, self.mult))
+
+
+class PotentialKey(DefaultModel):
+    id: str = Field(
+        ...,
+        description="A unique identifier of this potential, i.e. a SMARTS pattern or an atom type",
+    )
+    mult: Optional[int] = Field(
+        None, description="The index of this duplicate interaction"
+    )
+
+    def __hash__(self):
+        return hash((self.id, self.mult))

--- a/openff/system/tests/energy_tests/report.py
+++ b/openff/system/tests/energy_tests/report.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional
 
 from simtk import unit as omm_unit
 
-from openff.system.types import DefaultModel
+from openff.system.models import DefaultModel
 
 
 class EnergyError(BaseException):

--- a/openff/system/tests/test_potential.py
+++ b/openff/system/tests/test_potential.py
@@ -6,6 +6,7 @@ from simtk import unit as omm_unit
 
 from openff.system import unit
 from openff.system.components.potentials import PotentialHandler
+from openff.system.models import TopologyKey
 from openff.system.tests.base_test import BaseTest
 
 
@@ -40,7 +41,8 @@ class TestBondPotentialHandler(BaseTest):
         forcefield.register_parameter_handler(bond_handler)
         bond_potentials = forcefield["Bonds"].create_potential(top)
 
-        pot = bond_potentials.potentials[bond_potentials.slot_map["(0, 1)"]]
+        top_key = TopologyKey(atom_indices=(0, 1))
+        pot = bond_potentials.potentials[bond_potentials.slot_map[top_key]]
 
         kcal_mol_a2 = unit.Unit("kilocalorie / (angstrom ** 2 * mole)")
         assert pot.parameters["k"].to(kcal_mol_a2).magnitude == pytest.approx(1.5)
@@ -63,7 +65,8 @@ class TestBondPotentialHandler(BaseTest):
         forcefield.register_parameter_handler(angle_handler)
         angle_potentials = forcefield["Angles"].create_potential(top)
 
-        pot = angle_potentials.potentials[angle_potentials.slot_map["(0, 1, 2)"]]
+        top_key = TopologyKey(atom_indices=(0, 1, 2))
+        pot = angle_potentials.potentials[angle_potentials.slot_map[top_key]]
 
         kcal_mol_rad2 = unit.Unit("kilocalorie / (mole * radian ** 2)")
         assert pot.parameters["k"].to(kcal_mol_rad2).magnitude == pytest.approx(2.5)

--- a/openff/system/tests/test_stubs.py
+++ b/openff/system/tests/test_stubs.py
@@ -3,6 +3,7 @@ from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.utils import get_data_file_path
 
 from openff.system.exceptions import SMIRNOFFHandlersNotImplementedError
+from openff.system.models import TopologyKey
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.utils import compare_charges_omm_off, requires_pkg
 
@@ -47,13 +48,15 @@ class TestConstraints(BaseTest):
 
         assert "Constraints" in sys_out.handlers.keys()
         constraints = sys_out.handlers["Constraints"]
-        assert "(0, 1)" not in constraints.slot_map.keys()  # C-C bond
-        assert "(0, 2)" in constraints.slot_map.keys()  # C-H bond
+        c_c_bond = TopologyKey(atom_indices=(0, 1))  # C-C bond
+        assert c_c_bond not in constraints.slot_map.keys()
+        c_h_bond = TopologyKey(atom_indices=(0, 2))  # C-H bond
+        assert c_h_bond in constraints.slot_map.keys()
         assert len(constraints.slot_map.keys()) == 6  # number of C-H bonds
         assert len({constraints.slot_map.values()}) == 1  # always True
         assert (
             "distance"
-            in constraints.constraints[constraints.slot_map["(0, 2)"]].parameters
+            in constraints.constraints[constraints.slot_map[c_h_bond]].parameters
         )
 
     def test_force_field_no_constraints(self, parsley_unconstrained):

--- a/openff/system/tests/test_types.py
+++ b/openff/system/tests/test_types.py
@@ -8,7 +8,8 @@ from simtk import unit as omm_unit
 
 from openff.system import unit
 from openff.system.exceptions import UnitValidationError
-from openff.system.types import ArrayQuantity, DefaultModel, FloatQuantity
+from openff.system.models import DefaultModel
+from openff.system.types import ArrayQuantity, FloatQuantity
 
 
 class TestQuantityTypes:

--- a/openff/system/tests/test_typing.py
+++ b/openff/system/tests/test_typing.py
@@ -17,7 +17,8 @@ class TestSMIRNOFFTyping(BaseTest):
         assert "Electrostatics" in argon_sys.handlers
         assert "LibraryCharges" in argon_sys.handlers
 
-        found_smirks = argon_sys.handlers["vdW"].slot_map.values()
+        vdw_handler = argon_sys["vdW"]
+        found_smirks = [key.id for key in vdw_handler.slot_map.values()]
         assert all([smirks == "[#18:1]" for smirks in found_smirks])
 
         ammonia_sys = ammonia_ff.create_openff_system(ammonia_top)

--- a/openff/system/types.py
+++ b/openff/system/types.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict
 
 import numpy as np
 import unyt
-from pydantic import BaseModel
 from simtk import unit as omm_unit
 
 from openff.system import unit
@@ -193,13 +192,3 @@ else:
                     raise UnitValidationError(
                         f"Could not validate data of type {type(val)}"
                     )
-
-
-class DefaultModel(BaseModel):
-    class Config:
-        json_encoders = {
-            unit.Quantity: custom_quantity_encoder,
-        }
-        json_loads = json_loader
-        validate_assignment = True
-        arbitrary_types_allowed = True


### PR DESCRIPTION
### Description
This PR attempts a refactor to some components of the `PotentialHandler` objects. Topological locations are now constructed with `ToplogyKey`s and potentials are uniquely  identified with `PotentialKey`s.

An example (this is a parametrized ethanol):

```python3
In [11]: out['Bonds'].slot_map
Out[11]:
{TopologyKey(atom_indices=(0, 1), mult=None): PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None),
 TopologyKey(atom_indices=(0, 3), mult=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None),
 TopologyKey(atom_indices=(0, 4), mult=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None),
 TopologyKey(atom_indices=(0, 5), mult=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None),
 TopologyKey(atom_indices=(1, 2), mult=None): PotentialKey(id='[#6:1]-[#8:2]', mult=None),
 TopologyKey(atom_indices=(1, 6), mult=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None),
 TopologyKey(atom_indices=(1, 7), mult=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None),
 TopologyKey(atom_indices=(2, 8), mult=None): PotentialKey(id='[#8:1]-[#1:2]', mult=None)}

In [12]: out['Bonds'].potentials
Out[12]:
{PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None): Potential(parameters={'k': <Quantity(531.137374, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.5203759, 'angstrom')>}),
 PotentialKey(id='[#6X4:1]-[#1:2]', mult=None): Potential(parameters={'k': <Quantity(758.093177, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.09288838, 'angstrom')>}),
 PotentialKey(id='[#6:1]-[#8:2]', mult=None): Potential(parameters={'k': <Quantity(669.141517, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.41428792, 'angstrom')>}),
 PotentialKey(id='[#8:1]-[#1:2]', mult=None): Potential(parameters={'k': <Quantity(1120.58324, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(0.970768759, 'angstrom')>})}
```

The information content is roughly similar; the important part of a `TopologyKey` is still the atom indices of the interaction (whether this is a single atom, atoms in a bond, etc.) and the important part of a `PotentialKey` is still the SMIRKS pattern for SMIRNOFF-style force fields, but this can be atom types and other identifies for other force fields.

This somewhat hardens the API via using discrete classes/models for these keys instead of strings that only I know how to properly process.

### Checklist
- [ ] Document model structure in English
- [x] Update examples
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
