### PR TITLE
Add Ryckaert-Bellemans torsions

### DIFF
--- a/openff/system/components/misc.py
+++ b/openff/system/components/misc.py
@@ -15,3 +15,15 @@ class BuckinghamvdWHandler(PotentialHandler):
     scale_13: float = 0.0
     scale_14: float = 0.5
     scale_15: float = 1.0
+
+
+class RBTorsionHandler(PotentialHandler):
+    name = "Ryckaert-Bellemans"
+    expression = (
+        "C0 + C1 * (cos(phi - 180)) "
+        "C2 * (cos(phi - 180)) ** 2 + C3 * (cos(phi - 180)) ** 3 "
+        "C4 * (cos(phi - 180)) ** 4 + C5 * (cos(phi - 180)) ** 5 "
+    )
+    independent_variables: Set[str] = {"C0", "C1", "C2", "C3", "C4", "C5"}
+    slot_map: Dict[TopologyKey, PotentialKey] = dict()
+    potentials: Dict[PotentialKey, Potential] = dict()

--- a/openff/system/tests/energy_tests/openmm.py
+++ b/openff/system/tests/energy_tests/openmm.py
@@ -131,4 +131,7 @@ def _get_openmm_energies(
     if "CustomNonbondedForce" in omm_energies:
         report.energies["Nonbonded"] += omm_energies["CustomNonbondedForce"]
 
+    if "RBTorsionForce" in omm_energies:
+        report.energies["Torsion"] += omm_energies["RBTorsionForce"]
+
     return report

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -1,0 +1,43 @@
+from openff.toolkit.topology.molecule import Molecule
+
+from openff.system import unit
+from openff.system.components.misc import RBTorsionHandler
+from openff.system.components.potentials import Potential
+from openff.system.models import PotentialKey, TopologyKey
+from openff.system.stubs import ForceField
+
+kj_mol = unit.Unit("kilojoule / mol")
+
+
+def test_ethanol_opls():
+    mol = Molecule.from_smiles("CC")
+    mol.generate_conformers(n_conformers=1)
+    top = mol.to_topology()
+    parsley = ForceField("openff-1.0.0.offxml")
+    out = parsley.create_openff_system(top)
+    out.box = [4, 4, 4]
+    out.positions = mol.conformers[0]
+
+    # Values from HC-CT-CT-HC RB torsion
+    # https://github.com/mosdef-hub/foyer/blob/7816bf53a127502520a18d76c81510f96adfdbed/foyer/forcefields/xml/oplsaa.xml#L2585
+    rb_torsions = RBTorsionHandler()
+    smirks = "[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]"
+    pot_key = PotentialKey(id=smirks)
+    for proper in top.propers:
+        top_key = TopologyKey(atom_indices=tuple(a.topology_atom_index for a in proper))
+        rb_torsions.slot_map.update({top_key, pot_key})
+
+    pot = Potential(
+        parameters={
+            "c0": 1.6276 * kj_mol,
+            "c1": 1.8828 * kj_mol,
+            "c2": 0.0 * kj_mol,
+            "c3": -2.5104 * kj_mol,
+            "c4": 0.0 * kj_mol,
+            "c5": 0.0 * kj_mol,
+        }
+    )
+
+    rb_torsions.potentials.update({pot_key: pot})
+
+    out.handlers.update({"RBTorsions": rb_torsions})

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -46,7 +46,7 @@ def test_ethanol_opls():
     out.handlers.update({"RBTorsions": rb_torsions})
     out.handlers.pop("ProperTorsions")
 
-    gmx = get_openmm_energies(out).energies["Torsion"]
+    gmx = get_openmm_energies(out, round_positions=3).energies["Torsion"]
     omm = get_gromacs_energies(out).energies["Torsion"]
 
     assert (gmx - omm).value_in_unit(omm_unit.kilojoule_per_mole) < 1e-3

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -1,3 +1,4 @@
+import numpy as np
 from openff.toolkit.topology.molecule import Molecule
 from simtk import unit as omm_unit
 
@@ -24,6 +25,7 @@ def test_ethanol_opls():
     out = parsley.create_openff_system(top)
     out.box = [4, 4, 4]
     out.positions = mol.conformers[0]
+    out.positions = np.round(out.positions, 2)
 
     rb_torsions = RBTorsionHandler()
     smirks = "[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]"


### PR DESCRIPTION
### Description
This PR adds a shim for support Ryckaert-Bellemans torsions. If the parameter keys `c0`, `c1`, ..., `c5` are populated in a handler named `RBTorsions`, it should safely export to GROMACS and OpenMM.

Resolves #139

cc: @umesh-timalsina
### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
