### PR TITLE
Document energy tests

### DIFF
--- a/docs/energy_tests.md
+++ b/docs/energy_tests.md
@@ -8,7 +8,7 @@ There are also some internal functions that can be used to compute energies from
 
 This example shows many ways of computing single-point energies from a constructed `System` object.
 
-```
+```python3
 import numpy as np
 
 # Create an OpenFF System object from an OpenFF Molecule, Topology, and ForceField

--- a/docs/energy_tests.md
+++ b/docs/energy_tests.md
@@ -1,0 +1,60 @@
+## Energy Tests
+
+This project includes infrastructure for comparing representations of parametrized systems via computing single-point energies using molecular simulation engines.
+
+Currently, OpenMM, GROMACS, and LAMMPS are supported engines for running energy tests.
+There are high-level functions for computing energies from constructed `System` objects.
+There are also some internal functions that can be used to compute energies from other inputs.
+
+This example shows many ways of computing single-point energies from a constructed `System` object.
+
+```
+import numpy as np
+
+# Create an OpenFF System object from an OpenFF Molecule, Topology, and ForceField
+from openff.toolkit.topology import Molecule
+from openff.system.stubs import ForceField
+
+molecule = Molecule.from_smiles("CCO")
+molecule.generate_conformers(n_conformers=1)
+topology = molecule.to_topology()
+forcefield = ForceField('openff-1.2.0.offxml')
+openff_system = forcefield.create_openff_system(topology)
+openff_system.box = [5, 5, 5]
+openff_system.positions = np.round(molecule.conformers[0]._value / 10.0, 3)
+
+
+# Directly compute single-point energies via OpenMM, GROMACS, and LAMMPS
+from openff.system.tests.energy_tests.openmm import get_openmm_energies
+from openff.system.tests.energy_tests.gromacs import get_gromacs_energies
+from openff.system.tests.energy_tests.lammps import get_lammps_energies
+
+openmm_energies = get_openmm_energies(openff_system)
+gmx_energies = get_gromacs_energies(openff_system)
+lmp_energies = get_lammps_energies(openff_system)
+
+# Compare energies computed from different engines
+openmm_energies.compare(gmx_energies)  # EnergyError: ...
+gmx_energies.compare(lmp_energies)  # EnergyError: ...
+
+
+# Compute single-point energies from engine-specific files/objects
+from openff.system.tests.energy_tests.openmm import  _get_openmm_energies
+
+_get_openmm_energies(
+    omm_sys=openff_system.to_openmm(),
+    box_vectors=openff_system.box,
+    positions=openff_system.positions,
+)
+
+from openff_system.tests.energy_tests.gromacs import _run_gmx_energy, _get_mdp_file
+
+openff_sys.to_top("out.top", writer="internal")
+openff_sys.to_gro("out.gro", writer="internal")
+
+_run_gmx_energy(
+    top_file="out.top",
+    gro_file="out.gro",
+    mdp_file=_get_mdp_file("cutoff_hbonds"),
+)
+```

--- a/openff/system/tests/energy_tests/gromacs.py
+++ b/openff/system/tests/energy_tests/gromacs.py
@@ -13,7 +13,7 @@ from openff.system.tests.energy_tests.report import EnergyReport
 from openff.system.utils import get_test_file_path
 
 
-def get_mdp_file(key: str) -> Path:
+def _get_mdp_file(key: str) -> Path:
     mapping = {
         "default": "default.mdp",
         "cutoff": "cutoff.mdp",
@@ -30,27 +30,74 @@ def get_gromacs_energies(
     writer: str = "internal",
     electrostatics=True,
 ) -> EnergyReport:
+    """
+    Given an OpenFF System object, return single-point energies as computed by GROMACS.
+
+    .. warning :: This API is experimental and subject to change.
+
+    Parameters
+    ----------
+    off_sys : openff.system.components.system.System
+        An OpenFF System object to compute the single-point energy of
+    mdp : str, default="cutoff"
+        A string key identifying the GROMACS `.mdp` file to be used. See `_get_mdp_file`.
+    writer : str, default="internal"
+        A string key identifying the backend to be used to write GROMACS files. The
+        default value of `"internal"` results in this package's exporters being used.
+    electrostatics : bool, default=True
+        A boolean indicating whether or not electrostatics should be included in the energy
+        calculation.
+
+    Returns
+    -------
+    report : EnergyReport
+        An `EnergyReport` object containing the single-point energies.
+
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         with temporary_cd(tmpdir):
             off_sys.to_gro("out.gro", writer=writer)
             off_sys.to_top("out.top", writer=writer)
-            return run_gmx_energy(
+            report = _run_gmx_energy(
                 top_file="out.top",
                 gro_file="out.gro",
-                mdp_file=get_mdp_file(mdp),
+                mdp_file=_get_mdp_file(mdp),
                 maxwarn=2,
                 electrostatics=electrostatics,
             )
+            return report
 
 
-def run_gmx_energy(
+def _run_gmx_energy(
     top_file: Union[Path, str],
     gro_file: Union[Path, str],
     mdp_file: Union[Path, str],
     maxwarn: int = 1,
     electrostatics=True,
 ):
+    """
+    Given GROMACS files, return single-point energies as computed by GROMACS.
 
+    Parameters
+    ----------
+    top_file : str or pathlib.Path
+        The path to a GROMACS topology (`.top`) file.
+    gro_file : str or pathlib.Path
+        The path to a GROMACS coordinate (`.gro`) file.
+    mdp_file : str or pathlib.Path
+        The path to a GROMACS molecular dynamics parameters (`.mdp`) file.
+    maxwarn : int, default=1
+        The number of warnings to allow when `gmx grompp` is called (via the `-maxwarn` flag).
+    electrostatics : bool, default=True
+        A boolean indicated whether or not electrostatics should be included in the energy
+        calculation.
+
+    Returns
+    -------
+    report : EnergyReport
+        An `EnergyReport` object containing the single-point energies.
+
+    """
     grompp_cmd = f"gmx grompp --maxwarn {maxwarn} -o out.tpr"
     grompp_cmd += f" -f {mdp_file} -c {gro_file} -p {top_file}"
 
@@ -99,11 +146,13 @@ def run_gmx_energy(
     if energy.returncode:
         raise GMXRunError(err)
 
-    return _parse_gmx_energy("out.xvg", electrostatics=electrostatics)
+    report = _parse_gmx_energy("out.xvg", electrostatics=electrostatics)
+
+    return report
 
 
 def _get_gmx_energy_nonbonded(gmx_energies: Dict):
-    """Get the total nonbonded energy from a set of GROMACS energies"""
+    """Get the total nonbonded energy from a set of GROMACS energies."""
     gmx_nonbonded = 0.0 * omm_unit.kilojoule_per_mole
     for key in ["LJ (SR)", "Coulomb (SR)", "Coul. recip.", "Disper. corr."]:
         try:
@@ -115,6 +164,7 @@ def _get_gmx_energy_nonbonded(gmx_energies: Dict):
 
 
 def _parse_gmx_energy(xvg_path, electrostatics=True):
+    """Parse an `.xvg` file written by `gmx energy`."""
     energies, _ = _group_energy_terms(xvg_path)
 
     # TODO: Better way of filling in missing fields

--- a/openff/system/tests/energy_tests/lammps.py
+++ b/openff/system/tests/energy_tests/lammps.py
@@ -15,6 +15,33 @@ def get_lammps_energies(
     writer: str = "internal",
     electrostatics=True,
 ) -> EnergyReport:
+    """
+    Given an OpenFF System object, return single-point energies as computed by LAMMPS.
+
+    .. warning :: This API is experimental and subject to change.
+
+    .. todo :: Split out _running_ LAMMPS into a separate internal function
+
+    Parameters
+    ----------
+    off_sys : openff.system.components.system.System
+        An OpenFF System object to compute the single-point energy of
+    round_positions : int, optional
+        The number of decimal places, in nanometers, to round positions. This can be useful when
+        comparing to i.e. GROMACS energies, in which positions may be rounded.
+    writer : str, default="internal"
+        A string key identifying the backend to be used to write LAMMPS files. The
+        default value of `"internal"` results in this package's exporters being used.
+    electrostatics : bool, default=True
+        A boolean indicating whether or not electrostatics should be included in the energy
+        calculation.
+
+    Returns
+    -------
+    report : EnergyReport
+        An `EnergyReport` object containing the single-point energies.
+
+    """
 
     if round_positions is not None:
         off_sys.positions = np.round(off_sys.positions, round_positions)
@@ -57,6 +84,7 @@ def get_lammps_energies(
 
 
 def _parse_lammps_log(file_in) -> List[float]:
+    """Parse a LAMMPS log file for energy components."""
     tag = False
     with open(file_in) as fi:
         for line in fi.readlines():
@@ -74,7 +102,7 @@ def _write_lammps_input(
     file_name="test.in",
     electrostatics=False,
 ):
-
+    """Write a LAMMPS input file for running single-point energies."""
     with open(file_name, "w") as fo:
         fo.write(
             "units real\n" "atom_style full\n" "\n" "dimension 3\nboundary p p p\n\n"

--- a/openff/system/tests/energy_tests/openmm.py
+++ b/openff/system/tests/energy_tests/openmm.py
@@ -13,6 +13,35 @@ def get_openmm_energies(
     hard_cutoff: bool = True,
     electrostatics: bool = True,
 ) -> EnergyReport:
+    """
+    Given an OpenFF System object, return single-point energies as computed by OpenMM.
+
+    .. warning :: This API is experimental and subject to change.
+
+    Parameters
+    ----------
+    off_sys : openff.system.components.system.System
+        An OpenFF System object to compute the single-point energy of
+    round_positions : int, optional
+        The number of decimal places, in nanometers, to round positions. This can be useful when
+        comparing to i.e. GROMACS energies, in which positions may be rounded.
+    writer : str, default="internal"
+        A string key identifying the backend to be used to write OpenMM files. The
+        default value of `"internal"` results in this package's exporters being used.
+    hard_cutoff : bool, default=True
+        Whether or not to apply a hard cutoff (no switching function or disperson correction)
+        to the `openmm.NonbondedForce` in the generated `openmm.System`. Note that this will
+        truncate electrostatics to the non-bonded cutoff.
+    electrostatics : bool, default=True
+        A boolean indicating whether or not electrostatics should be included in the energy
+        calculation.
+
+    Returns
+    -------
+    report : EnergyReport
+        An `EnergyReport` object containing the single-point energies.
+
+    """
 
     omm_sys: openmm.System = off_sys.to_openmm()
 
@@ -26,12 +55,12 @@ def get_openmm_energies(
     )
 
 
-def set_nonbonded_method(
+def _set_nonbonded_method(
     omm_sys: openmm.System,
     key: str,
     electrostatics: bool = True,
 ) -> openmm.System:
-
+    """Modify the `openmm.NonbondedForce` in this `openmm.System`."""
     if key == "cutoff":
         for force in omm_sys.getForces():
             if type(force) == openmm.NonbondedForce:
@@ -67,11 +96,13 @@ def _get_openmm_energies(
     hard_cutoff=False,
     electrostatics: bool = True,
 ) -> EnergyReport:
-
+    """Given a prepared `openmm.System`, run a single-point energy calculation."""
     if hard_cutoff:
-        omm_sys = set_nonbonded_method(omm_sys, "cutoff", electrostatics=electrostatics)
+        omm_sys = _set_nonbonded_method(
+            omm_sys, "cutoff", electrostatics=electrostatics
+        )
     else:
-        omm_sys = set_nonbonded_method(omm_sys, "PME")
+        omm_sys = _set_nonbonded_method(omm_sys, "PME")
 
     force_names = {force.__class__.__name__ for force in omm_sys.getForces()}
     group_to_force = {i: force_name for i, force_name in enumerate(force_names)}

--- a/openff/system/tests/energy_tests/test_energies.py
+++ b/openff/system/tests/energy_tests/test_energies.py
@@ -8,9 +8,9 @@ from simtk import unit as omm_unit
 from openff.system import unit
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.gromacs import (
+    _get_mdp_file,
+    _run_gmx_energy,
     get_gromacs_energies,
-    get_mdp_file,
-    run_gmx_energy,
 )
 from openff.system.tests.energy_tests.lammps import get_lammps_energies
 from openff.system.tests.energy_tests.openmm import (
@@ -310,8 +310,8 @@ def test_process_rb_torsions():
     struct.save("eth.gro", overwrite=True)
 
     # Get single-point energies using GROMACS
-    oplsaa_energies = run_gmx_energy(
-        top_file="eth.top", gro_file="eth.gro", mdp_file=get_mdp_file("default")
+    oplsaa_energies = _run_gmx_energy(
+        top_file="eth.top", gro_file="eth.gro", mdp_file=_get_mdp_file("default")
     )
 
     assert oplsaa_energies.energies["Torsion"]._value != 0.0

--- a/openff/system/tests/test_interop/test_internal_writers.py
+++ b/openff/system/tests/test_interop/test_internal_writers.py
@@ -10,9 +10,9 @@ from simtk import unit as omm_unit
 from openff.system import unit
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.gromacs import (
+    _get_mdp_file,
+    _run_gmx_energy,
     get_gromacs_energies,
-    get_mdp_file,
-    run_gmx_energy,
 )
 
 
@@ -59,16 +59,16 @@ def test_internal_gromacs_writers(mol):
             compare_gro_files("internal.gro", "reference.gro")
             # TODO: Also compare to out.to_gro("parmed.gro", writer="parmed")
 
-            reference_energy = run_gmx_energy(
+            reference_energy = _run_gmx_energy(
                 top_file="reference.top",
                 gro_file="reference.gro",
-                mdp_file=get_mdp_file("default"),
+                mdp_file=_get_mdp_file("default"),
             )
 
-            internal_energy = run_gmx_energy(
+            internal_energy = _run_gmx_energy(
                 top_file="internal.top",
                 gro_file="internal.gro",
-                mdp_file=get_mdp_file("default"),
+                mdp_file=_get_mdp_file("default"),
             )
 
             reference_energy.compare(

--- a/openff/system/tests/test_parmed.py
+++ b/openff/system/tests/test_parmed.py
@@ -4,9 +4,9 @@ from simtk import unit as omm_unit
 from openff.system.interop.parmed import from_parmed
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.energy_tests.gromacs import (
+    _get_mdp_file,
+    _run_gmx_energy,
     get_gromacs_energies,
-    get_mdp_file,
-    run_gmx_energy,
 )
 from openff.system.utils import get_test_file_path
 
@@ -24,17 +24,17 @@ class TestParmEd(BaseTest):
         roundtrip.save("conv.gro", overwrite=True)
         roundtrip.save("conv.top", overwrite=True)
 
-        original_energy = run_gmx_energy(
+        original_energy = _run_gmx_energy(
             top_file=get_test_file_path("ALA_GLY/ALA_GLY.top"),
             gro_file=get_test_file_path("ALA_GLY/ALA_GLY.gro"),
-            mdp_file=get_mdp_file("cutoff_hbonds"),
+            mdp_file=_get_mdp_file("cutoff_hbonds"),
         )
         internal_energy = get_gromacs_energies(openff_sys, mdp="cutoff_hbonds")
 
-        roundtrip_energy = run_gmx_energy(
+        roundtrip_energy = _run_gmx_energy(
             top_file="conv.top",
             gro_file="conv.gro",
-            mdp_file=get_mdp_file("cutoff_hbonds"),
+            mdp_file=_get_mdp_file("cutoff_hbonds"),
         )
 
         # Differences in bond energies appear to be related to ParmEd's rounding

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -8,9 +8,9 @@ from openff.system.components.potentials import Potential
 from openff.system.models import PotentialKey, TopologyKey
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.gromacs import (
+    _get_mdp_file,
+    _run_gmx_energy,
     get_gromacs_energies,
-    get_mdp_file,
-    run_gmx_energy,
 )
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
 
@@ -73,10 +73,10 @@ def test_ethanol_opls():
     from_foyer.save("from_foyer.top")
     from_foyer.save("from_foyer.gro")
 
-    rb_torsion_energy_from_foyer = run_gmx_energy(
+    rb_torsion_energy_from_foyer = _run_gmx_energy(
         top_file="from_foyer.top",
         gro_file="from_foyer.gro",
-        mdp_file=get_mdp_file("default"),
+        mdp_file=_get_mdp_file("default"),
     ).energies["Torsion"]
 
     assert (omm - rb_torsion_energy_from_foyer).value_in_unit(


### PR DESCRIPTION
### Description
This PR adds some rough initial documentation for the energy tests, including some docstrings.


The important points relating to GROMACS are
1. Call `get_gromacs_energies` directly on a `System` object to get single-point energies
2. Call `_run_gmx_energy` on a collection of GROMACS files (prepared here or externally, i.e. via ParmEd) to get single-point energies. `get_gromacs_energies` calls this function, so the behavior should be similar (or able to be made similar).
3. I've hacked together a few `.mdp` files to cover some types of calculations, but these are not exhaustive and a better solution (programmatically generating them?) should replace these in the future. For now, see [this](https://github.com/openforcefield/openff-system/tree/9bca382ba64aede0be9e9138159db51a58f7a7c8/openff/system/tests/files/mdp) path.

cc: @justingilmer, @umesh-timalsina @daico007 - feedback welcome

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
