### PR TITLE
Make ParmEd conversion methods private

### DIFF
--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -14,7 +14,6 @@ from openff.system.exceptions import (
     UnsupportedExportError,
 )
 from openff.system.interop.openmm import to_openmm
-from openff.system.interop.parmed import to_parmed
 from openff.system.models import DefaultModel
 from openff.system.types import ArrayQuantity
 
@@ -86,9 +85,17 @@ class System(DefaultModel):
         self._check_nonbonded_compatibility()
         return to_openmm(self)
 
-    def to_parmed(self):
-        """Export this sytem to a ParmEd Structure"""
-        return to_parmed(self)
+    def _to_parmed(self):
+        """Export this system to a ParmEd Structure"""
+        from openff.system.interop.parmed import _to_parmed
+
+        return _to_parmed(self)
+
+    @classmethod
+    def _from_parmed(cls, structure):
+        from openff.system.interop.parmed import _from_parmed
+
+        return _from_parmed(cls, structure)
 
     def _get_nonbonded_methods(self):
         if "vdW" in self.handlers:

--- a/openff/system/interop/external.py
+++ b/openff/system/interop/external.py
@@ -44,6 +44,6 @@ class ParmEdWrapper(InteroperabilityWrapper):
         if openff_sys.box is None:
             raise MissingBoxError
 
-        struct = openff_sys.to_parmed()
+        struct = openff_sys._to_parmed()
 
         struct.save(path.as_posix(), overwrite=True)

--- a/openff/system/tests/integration_tests/test_interoperability_pathways.py
+++ b/openff/system/tests/integration_tests/test_interoperability_pathways.py
@@ -54,7 +54,7 @@ def openff_pmd_gmx_indirect(
     # TODO: Update this when better processing of OFFTop positions is supported
     off_sys.positions = off_top_positions
 
-    struct = off_sys.to_parmed()
+    struct = off_sys._to_parmed()
 
     struct.save(prefix + ".gro")
     struct.save(prefix + ".top")

--- a/openff/system/tests/test_interop/test_parmed.py
+++ b/openff/system/tests/test_interop/test_parmed.py
@@ -17,7 +17,7 @@ class TestParmedConversion(BaseTest):
         off_sys.positions = (
             np.zeros(shape=(argon_top.n_topology_atoms, 3)) * unit.angstrom
         )
-        struct = off_sys.to_parmed()
+        struct = off_sys._to_parmed()
 
         assert np.allclose(
             struct.box[:3],
@@ -27,7 +27,7 @@ class TestParmedConversion(BaseTest):
     def test_basic_conversion_argon(self, argon_ff, argon_top, box):
         off_sys = argon_ff.create_openff_system(argon_top, box=box)
         off_sys.positions = np.zeros(shape=(argon_top.n_topology_atoms, 3))
-        struct = off_sys.to_parmed()
+        struct = off_sys._to_parmed()
 
         # As partial sanity check, see if it they save without error
         struct.save("x.top", combine="all")
@@ -42,7 +42,7 @@ class TestParmedConversion(BaseTest):
         off_sys = parsley.create_openff_system(topology=top, box=box)
         # UnitArray(...)
         off_sys.positions = np.zeros(shape=(top.n_topology_atoms, 3))
-        struct = off_sys.to_parmed()
+        struct = off_sys._to_parmed()
 
         sigma0 = struct.atoms[0].atom_type.sigma
         epsilon0 = struct.atoms[0].atom_type.epsilon
@@ -73,7 +73,7 @@ class TestParmedConversion(BaseTest):
     def test_basic_conversion_ammonia(self, ammonia_ff, ammonia_top, box):
         off_sys = ammonia_ff.create_openff_system(ammonia_top, box=box)
         off_sys.positions = np.zeros(shape=(ammonia_top.n_topology_atoms, 3))
-        struct = off_sys.to_parmed()
+        struct = off_sys._to_parmed()
 
         # As partial sanity check, see if it they save without error
         struct.save("x.top", combine="all")

--- a/openff/system/tests/test_parmed.py
+++ b/openff/system/tests/test_parmed.py
@@ -1,7 +1,7 @@
 import parmed as pmd
 from simtk import unit as omm_unit
 
-from openff.system.interop.parmed import from_parmed
+from openff.system.components.system import System
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.energy_tests.gromacs import (
     get_gromacs_energies,
@@ -18,8 +18,8 @@ class TestParmEd(BaseTest):
         original.box = gro.box
         original.positions = gro.positions
 
-        openff_sys = from_parmed(original)
-        roundtrip = openff_sys.to_parmed()
+        openff_sys = System._from_parmed(original)
+        roundtrip = openff_sys._to_parmed()
 
         roundtrip.save("conv.gro", overwrite=True)
         roundtrip.save("conv.top", overwrite=True)


### PR DESCRIPTION
### Description
This PR makes the ParmEd API points private. I forgot to do it in #145.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
