### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,11 +67,10 @@ jobs:
         pip install git+git://github.com/mattwthompson/openff-units.git
 
     - name: Clone ParmEd tests
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       shell: bash -l {0}
       run: |
         git clone https://github.com/parmed/tests
-        cp -r tests/pmdtest/ .
+        cp -r tests/pmdtest .
         echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
 
     - name: Run mypy
@@ -85,7 +84,6 @@ jobs:
         python -m pytest -v $COV openff/system/tests/ --ignore=openff/system/tests/parmed/
 
     - name: Run ParmEd tests
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       shell: bash -l {0}
       run: |
         python -m pytest -v $COV openff/system/tests/parmed

--- a/openff/system/tests/energy_tests/test_energies.py
+++ b/openff/system/tests/energy_tests/test_energies.py
@@ -22,6 +22,7 @@ from openff.system.tests.energy_tests.openmm import (
 from openff.system.tests.energy_tests.report import EnergyError
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("constrained", [True, False])
 @pytest.mark.parametrize("mol_smi", ["C"])  # ["C", "CC"]
 @pytest.mark.parametrize("n_mol", [1, 10, 100])
@@ -129,6 +130,7 @@ def test_energies_single_mol(constrained, n_mol, mol_smi):
         lmp_energies.compare(other_energies, custom_tolerances=custom_tolerances)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("n_mol", [10, 100])
 def test_argon(n_mol):
     from openff.system.utils import get_test_file_path
@@ -248,6 +250,7 @@ def test_packmol_boxes(toolkit_file_path):
     )
 
 
+@pytest.mark.slow
 def test_water_dimer():
     from openff.system.utils import get_test_file_path
 
@@ -288,6 +291,7 @@ def test_water_dimer():
     lmp_energies.compare(omm_energies)
 
 
+@pytest.mark.slow
 def test_process_rb_torsions():
     """Test that the GROMACS driver reports Ryckaert-Bellemans torsions"""
 

--- a/openff/system/tests/energy_tests/test_energies.py
+++ b/openff/system/tests/energy_tests/test_energies.py
@@ -316,4 +316,4 @@ def test_process_rb_torsions():
         top_file="eth.top", gro_file="eth.gro", mdp_file=_get_mdp_file("default")
     )
 
-    assert oplsaa_energies.energies["Torsion"]._value != 0.0
+    assert oplsaa_energies.energies["Torsion"].m != 0.0

--- a/openff/system/tests/integration_tests/test_interoperability_pathways.py
+++ b/openff/system/tests/integration_tests/test_interoperability_pathways.py
@@ -77,6 +77,7 @@ def openff_pmd_gmx_direct(
     off_sys.to_top(prefix + ".top")
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("smiles", ["C"])
 def test_parmed_openmm(tmpdir, smiles):
     tmpdir.chdir()

--- a/openff/system/tests/parmed/test_amber.py
+++ b/openff/system/tests/parmed/test_amber.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from openff.units import unit
 from parmed.amber import readparm
 from pmdtest.utils import get_fn as get_pmd_fn
@@ -7,6 +8,7 @@ from openff.system.components.system import System
 
 
 class TestParmEdAmber:
+    @pytest.mark.slow
     def test_load_prmtop(self):
         struct = readparm.LoadParm(get_pmd_fn("trx.prmtop"))
         other_struct = readparm.AmberParm(get_pmd_fn("trx.prmtop"))
@@ -25,6 +27,7 @@ class TestParmEdAmber:
             prmtop_converted.box, np.eye(3) * 2.0 * unit.nanometer
         )
 
+    @pytest.mark.slow
     def test_read_box_parm7(self):
         top = readparm.LoadParm(get_pmd_fn("solv2.parm7"))
         out = System._from_parmed(top)

--- a/openff/system/tests/test_amber_energy.py
+++ b/openff/system/tests/test_amber_energy.py
@@ -1,3 +1,4 @@
+import pytest
 from openff.toolkit.topology import Molecule
 from openff.units import unit
 
@@ -8,6 +9,7 @@ from openff.system.tests.energy_tests.gromacs import get_gromacs_energies
 kj_mol = unit.kilojoule / unit.mol
 
 
+@pytest.mark.slow
 def test_amber_energy():
     """Basic test to see if the amber energy driver is functional"""
     mol = Molecule.from_smiles("CCO")

--- a/openff/system/tests/test_amber_energy.py
+++ b/openff/system/tests/test_amber_energy.py
@@ -1,9 +1,11 @@
 from openff.toolkit.topology import Molecule
-from simtk import unit as omm_unit
+from openff.units import unit
 
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.amber import get_amber_energies
 from openff.system.tests.energy_tests.gromacs import get_gromacs_energies
+
+kj_mol = unit.kilojoule / unit.mol
 
 
 def test_amber_energy():
@@ -23,9 +25,9 @@ def test_amber_energy():
     omm_energies.compare(
         amb_energies,
         custom_tolerances={
-            "Bond": 3.6 * omm_unit.kilojoule_per_mole,
-            "Angle": 0.2 * omm_unit.kilojoule_per_mole,
-            "Torsion": 1.9 * omm_unit.kilojoule_per_mole,
-            "Nonbonded": 34.9 * omm_unit.kilojoule_per_mole,
+            "Bond": 3.6 * kj_mol,
+            "Angle": 0.2 * kj_mol,
+            "Torsion": 1.9 * kj_mol,
+            "Nonbonded": 34.9 * kj_mol,
         },
     )

--- a/openff/system/tests/test_buckingham.py
+++ b/openff/system/tests/test_buckingham.py
@@ -63,7 +63,7 @@ def test_argon_buck():
     omm_energies = get_openmm_energies(out)
     by_hand = A * exp(-B * r) - C * r ** -6
 
-    resid = simtk_to_pint(omm_energies.energies["Nonbonded"]) - by_hand
+    resid = omm_energies.energies["Nonbonded"] - by_hand
     assert resid < 1e-5 * unit.kilojoule / unit.mol
 
     # TODO: Add back comparison to GROMACS energies once GROMACS 2020+

--- a/openff/system/tests/test_external.py
+++ b/openff/system/tests/test_external.py
@@ -16,6 +16,7 @@ from openff.system.utils import get_test_file_path
 
 
 class TestFromOpenMM(BaseTest):
+    @pytest.mark.slow
     def test_from_openmm_pdbfile(self, argon_ff, argon_top):
         pdb_file_path = get_test_file_path("10-argons.pdb")
         pdbfile = openmm.app.PDBFile(pdb_file_path)
@@ -50,6 +51,7 @@ class TestFromOpenMM(BaseTest):
         # What if, instead ...
         # Molecule.from_iupac(molecules)
 
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "pdb_path",
         [

--- a/openff/system/tests/test_foyer.py
+++ b/openff/system/tests/test_foyer.py
@@ -2,7 +2,8 @@ import foyer
 import pytest
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.utils import get_data_file_path
-from simtk import unit as omm_unit
+from openff.units import unit
+from simtk import unit as simtk_unit
 
 from openff.system.components.foyer import from_foyer
 from openff.system.tests.base_test import BaseTest
@@ -18,7 +19,7 @@ class TestFoyer(BaseTest):
         top = Topology.from_molecules(molecule)
         oplsaa = foyer.Forcefield(name="oplsaa")
         system = from_foyer(topology=top, ff=oplsaa)
-        system.positions = molecule.conformers[0].value_in_unit(omm_unit.nanometer)
+        system.positions = molecule.conformers[0].value_in_unit(simtk_unit.nanometer)
         system.box = [4, 4, 4]
         return system
 
@@ -35,5 +36,5 @@ class TestFoyer(BaseTest):
 
         gmx_energies.compare(
             omm_energies,
-            custom_tolerances={"Nonbonded": 40.0 * omm_unit.kilojoule_per_mole},
+            custom_tolerances={"Nonbonded": 40.0 * unit.kilojoule / unit.mole},
         )

--- a/openff/system/tests/test_foyer.py
+++ b/openff/system/tests/test_foyer.py
@@ -30,6 +30,7 @@ class TestFoyer(BaseTest):
         assert oplsaa_system_ethanol["vdW"].scale_14 == 0.5
         assert oplsaa_system_ethanol["Electrostatics"].scale_14 == 0.5
 
+    @pytest.mark.slow
     def test_ethanol_energies(self, oplsaa_system_ethanol):
         gmx_energies = get_gromacs_energies(oplsaa_system_ethanol)
         omm_energies = get_openmm_energies(oplsaa_system_ethanol)

--- a/openff/system/tests/test_interop/test_internal_writers.py
+++ b/openff/system/tests/test_interop/test_internal_writers.py
@@ -17,6 +17,7 @@ from openff.system.tests.energy_tests.gromacs import (
 
 
 # TODO: Add OC=O
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "mol",
     [
@@ -87,6 +88,7 @@ def compare_gro_files(file1: str, file2: str):
                 assert line1[:10] + line1[15:] == line2[:10] + line2[15:]
 
 
+@pytest.mark.slow
 def test_sanity_grompp():
     """Basic test to ensure that a topology can be processed without errors"""
     mol = Molecule.from_smiles("CC")
@@ -105,6 +107,7 @@ def test_sanity_grompp():
     get_gromacs_energies(off_sys)
 
 
+@pytest.mark.slow
 def test_water_dimer():
     """Test that a water dimer can be written and the files can be grommp'd"""
     from openff.system.utils import get_test_file_path

--- a/openff/system/tests/test_interop/test_lammps.py
+++ b/openff/system/tests/test_interop/test_lammps.py
@@ -11,6 +11,7 @@ from openff.system.tests.energy_tests.lammps import (
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("n_mols", [1, 2])
 @pytest.mark.parametrize(
     "mol",

--- a/openff/system/tests/test_interop/test_openmm.py
+++ b/openff/system/tests/test_interop/test_openmm.py
@@ -8,6 +8,7 @@ from openff.system.stubs import ForceField
 from openff.system.utils import get_test_file_path
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("n_mols", [1, 2])
 @pytest.mark.parametrize(
     "mol",

--- a/openff/system/tests/test_interop/test_openmm_roundtrip.py
+++ b/openff/system/tests/test_interop/test_openmm_roundtrip.py
@@ -1,3 +1,4 @@
+import pytest
 from openff.toolkit.topology import Molecule
 from simtk import unit as omm_unit
 
@@ -6,6 +7,7 @@ from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
 
 
+@pytest.mark.slow
 def test_openmm_roundtrip():
     mol = Molecule.from_smiles("CCO")
     mol.generate_conformers(n_conformers=1)

--- a/openff/system/tests/test_parmed.py
+++ b/openff/system/tests/test_parmed.py
@@ -1,5 +1,6 @@
 import mdtraj as md
 import parmed as pmd
+import pytest
 from simtk import unit as omm_unit
 
 from openff.system.components.system import System
@@ -13,6 +14,7 @@ from openff.system.utils import get_test_file_path
 
 
 class TestParmEd(BaseTest):
+    @pytest.mark.slow
     def test_parmed_roundtrip(self):
         original = pmd.load_file(get_test_file_path("ALA_GLY/ALA_GLY.top"))
         gro = pmd.load_file(get_test_file_path("ALA_GLY/ALA_GLY.gro"))

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -20,7 +20,7 @@ kj_mol = unit.Unit("kilojoule / mol")
 
 
 class TestRBTorsions(BaseTest):
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="class")
     def ethanol_with_rb_torsions(self):
         mol = Molecule.from_smiles("CC")
         mol.generate_conformers(n_conformers=1)
@@ -60,6 +60,7 @@ class TestRBTorsions(BaseTest):
 
         return out
 
+    @pytest.mark.slow
     def test_rb_torsions(self, ethanol_with_rb_torsions):
         gmx = get_openmm_energies(ethanol_with_rb_torsions, round_positions=3).energies[
             "Torsion"
@@ -68,6 +69,7 @@ class TestRBTorsions(BaseTest):
 
         assert (gmx - omm).m_as(kj_mol) < 1e-6
 
+    @pytest.mark.slow
     @requires_pkg("foyer")
     @requires_pkg("mbuild")
     def test_rb_torsions_vs_foyer(self, ethanol_with_rb_torsions):

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -1,84 +1,96 @@
 import numpy as np
+import pytest
 from openff.toolkit.topology.molecule import Molecule
 from openff.units import unit
-from simtk import unit as omm_unit
 
 from openff.system.components.misc import RBTorsionHandler
 from openff.system.components.potentials import Potential
 from openff.system.models import PotentialKey, TopologyKey
 from openff.system.stubs import ForceField
+from openff.system.tests.base_test import BaseTest
 from openff.system.tests.energy_tests.gromacs import (
     _get_mdp_file,
     _run_gmx_energy,
     get_gromacs_energies,
 )
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
+from openff.system.tests.utils import requires_pkg
 
 kj_mol = unit.Unit("kilojoule / mol")
 
 
-def test_ethanol_opls():
-    mol = Molecule.from_smiles("CC")
-    mol.generate_conformers(n_conformers=1)
-    top = mol.to_topology()
-    parsley = ForceField("openff-1.0.0.offxml")
-    out = parsley.create_openff_system(top)
-    out.box = [4, 4, 4]
-    out.positions = mol.conformers[0]
-    out.positions = np.round(out.positions, 2)
+class TestRBTorsions(BaseTest):
+    @pytest.fixture(scope="session")
+    def ethanol_with_rb_torsions(self):
+        mol = Molecule.from_smiles("CC")
+        mol.generate_conformers(n_conformers=1)
+        top = mol.to_topology()
+        parsley = ForceField("openff-1.0.0.offxml")
+        out = parsley.create_openff_system(top)
+        out.box = [4, 4, 4]
+        out.positions = mol.conformers[0]
+        out.positions = np.round(out.positions, 2)
 
-    rb_torsions = RBTorsionHandler()
-    smirks = "[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]"
-    pot_key = PotentialKey(id=smirks)
-    for proper in top.propers:
-        top_key = TopologyKey(atom_indices=tuple(a.topology_atom_index for a in proper))
-        rb_torsions.slot_map.update({top_key: pot_key})
+        rb_torsions = RBTorsionHandler()
+        smirks = "[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]"
+        pot_key = PotentialKey(id=smirks)
+        for proper in top.propers:
+            top_key = TopologyKey(
+                atom_indices=tuple(a.topology_atom_index for a in proper)
+            )
+            rb_torsions.slot_map.update({top_key: pot_key})
 
-    # Values from HC-CT-CT-HC RB torsion
-    # https://github.com/mosdef-hub/foyer/blob/7816bf53a127502520a18d76c81510f96adfdbed/foyer/forcefields/xml/oplsaa.xml#L2585
-    pot = Potential(
-        parameters={
-            "C0": 0.6276 * kj_mol,
-            "C1": 1.8828 * kj_mol,
-            "C2": 0.0 * kj_mol,
-            "C3": -2.5104 * kj_mol,
-            "C4": 0.0 * kj_mol,
-            "C5": 0.0 * kj_mol,
-        }
-    )
+        # Values from HC-CT-CT-HC RB torsion
+        # https://github.com/mosdef-hub/foyer/blob/7816bf53a127502520a18d76c81510f96adfdbed/foyer/forcefields/xml/oplsaa.xml#L2585
+        pot = Potential(
+            parameters={
+                "C0": 0.6276 * kj_mol,
+                "C1": 1.8828 * kj_mol,
+                "C2": 0.0 * kj_mol,
+                "C3": -2.5104 * kj_mol,
+                "C4": 0.0 * kj_mol,
+                "C5": 0.0 * kj_mol,
+            }
+        )
 
-    rb_torsions.potentials.update({pot_key: pot})
+        rb_torsions.potentials.update({pot_key: pot})
 
-    out.handlers.update({"RBTorsions": rb_torsions})
-    out.handlers.pop("ProperTorsions")
+        out.handlers.update({"RBTorsions": rb_torsions})
+        out.handlers.pop("ProperTorsions")
 
-    gmx = get_openmm_energies(out, round_positions=3).energies["Torsion"]
-    omm = get_gromacs_energies(out).energies["Torsion"]
+        return out
 
-    assert (gmx - omm).value_in_unit(omm_unit.kilojoule_per_mole) < 1e-3
+    def test_rb_torsions(self, ethanol_with_rb_torsions):
+        gmx = get_openmm_energies(ethanol_with_rb_torsions, round_positions=3).energies[
+            "Torsion"
+        ]
+        omm = get_gromacs_energies(ethanol_with_rb_torsions).energies["Torsion"]
 
-    # Given that these force constants are copied from Foyer's OPLS-AA file,
-    # compare to processing through the current MoSDeF pipeline
-    try:
+        assert (gmx - omm).m_as(kj_mol) < 1e-6
+
+    @requires_pkg("foyer")
+    @requires_pkg("mbuild")
+    def test_rb_torsions_vs_foyer(self, ethanol_with_rb_torsions):
+        # Given that these force constants are copied from Foyer's OPLS-AA file,
+        # compare to processing through the current MoSDeF pipeline
         import foyer
         import mbuild
-    except ModuleNotFoundError:
-        return
 
-    comp = mbuild.load("CC", smiles=True)
-    comp.xyz = mol.conformers[0].value_in_unit(omm_unit.nanometer)
-    ff = foyer.Forcefield(name="oplsaa")
-    from_foyer = ff.apply(comp)
-    from_foyer.box = [40, 40, 40, 90, 90, 90]
-    from_foyer.save("from_foyer.top")
-    from_foyer.save("from_foyer.gro")
+        comp = mbuild.load("CC", smiles=True)
+        comp.xyz = ethanol_with_rb_torsions.positions.m_as(unit.nanometer)
+        ff = foyer.Forcefield(name="oplsaa")
+        from_foyer = ff.apply(comp)
+        from_foyer.box = [40, 40, 40, 90, 90, 90]
+        from_foyer.save("from_foyer.top")
+        from_foyer.save("from_foyer.gro")
 
-    rb_torsion_energy_from_foyer = _run_gmx_energy(
-        top_file="from_foyer.top",
-        gro_file="from_foyer.gro",
-        mdp_file=_get_mdp_file("default"),
-    ).energies["Torsion"]
+        rb_torsion_energy_from_foyer = _run_gmx_energy(
+            top_file="from_foyer.top",
+            gro_file="from_foyer.gro",
+            mdp_file=_get_mdp_file("default"),
+        ).energies["Torsion"]
 
-    assert (omm - rb_torsion_energy_from_foyer).value_in_unit(
-        omm_unit.kilojoule_per_mole
-    ) < 1e-3
+        # GROMACS vs. OpenMM was already compared, so just use one
+        omm = get_gromacs_energies(ethanol_with_rb_torsions).energies["Torsion"]
+
+        assert (omm - rb_torsion_energy_from_foyer).m_as(kj_mol) < 1e-6

--- a/openff/system/tests/test_residue.py
+++ b/openff/system/tests/test_residue.py
@@ -1,4 +1,5 @@
 import mdtraj as md
+import pytest
 from openff.toolkit.topology import Molecule
 from simtk.openmm import app
 
@@ -8,6 +9,7 @@ from openff.system.tests.energy_tests.openmm import get_openmm_energies
 from openff.system.utils import get_test_file_path
 
 
+@pytest.mark.slow
 def test_residues():
     pdb = app.PDBFile(get_test_file_path("ALA_GLY/ALA_GLY.pdb"))
     traj = md.load(get_test_file_path("ALA_GLY/ALA_GLY.pdb"))

--- a/openff/system/tests/test_stubs.py
+++ b/openff/system/tests/test_stubs.py
@@ -116,6 +116,7 @@ class TestConstraints(BaseTest):
 
 
 class TestChargeAssignment(BaseTest):
+    @pytest.mark.slow
     def test_default_am1bcc_charge_assignment(self, parsley):
         top = Topology.from_molecules(
             [


### PR DESCRIPTION
### Description
Chipping away at some debt before it calcifies.
* Energies in `EnergyReport.energies` are now stored with OpenFF units instead of SimTK units.
* Tests taking more than about 1 second on my machine are now marked as "slow"
* Better canonicalizing of some energy types in energy tests
* Fix copying `pmdtest` on macOS (thanks @jaimergp!)

Tests (with `pytest -v -m "not slow" openff/system/tests`) now run in about 20 seconds, down from ~3 minutes, with the slowest tests taking ~30s each.

### Checklist
- [ ] Add tests
- [xw] Lint
- [ ] Update docstrings
