### PR TITLE
Update API with outer/inner data

### DIFF
--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -281,13 +281,16 @@ def _process_nonbonded_forces(openff_sys, openmm_sys):
             # non_bonded_force.setUseDispersionCorrection(True)
             non_bonded_force.setCutoffDistance(vdw_cutoff)
             if getattr(vdw_handler, "switch_width", None) is not None:
-                switching_distance = vdw_handler.cutoff - vdw_handler.switch_width
-                switching_distance = (
-                    switching_distance.m_as(off_unit.angstrom) * unit.angstrom
-                )
+                if vdw_handler.switch_width == 0.0:
+                    non_bonded_force.setUseSwitchingFunction(False)
+                else:
+                    switching_distance = vdw_handler.cutoff - vdw_handler.switch_width
+                    switching_distance = (
+                        switching_distance.m_as(off_unit.angstrom) * unit.angstrom
+                    )
 
-                non_bonded_force.setUseSwitchingFunction(True)
-                non_bonded_force.setSwitchingDistance(switching_distance)
+                    non_bonded_force.setUseSwitchingFunction(True)
+                    non_bonded_force.setSwitchingDistance(switching_distance)
 
         for top_key, pot_key in vdw_handler.slot_map.items():
             atom_idx = top_key.atom_indices[0]

--- a/openff/system/tests/energy_tests/lammps.py
+++ b/openff/system/tests/energy_tests/lammps.py
@@ -129,6 +129,7 @@ def _write_lammps_input(
         # TODO: Ensure units
         vdw_cutoff = vdw_hander.cutoff  # type: ignore[attr-defined]
         vdw_cutoff = vdw_cutoff.m_as(unit.angstrom)
+
         # TODO: Handle separate cutoffs
         coul_cutoff = vdw_cutoff
 
@@ -148,7 +149,7 @@ def _write_lammps_input(
         else:
             fo.write(f"pair_style lj/cut {vdw_cutoff}\n")
 
-        fo.write("pair_modify mix arithmetic\n\n")
+        fo.write("pair_modify mix arithmetic tail yes\n\n")
         fo.write("read_data out.lmp\n\n")
         fo.write(
             "thermo_style custom ebond eangle edihed eimp epair evdwl ecoul elong etail pe\n\n"

--- a/openff/system/tests/test_combination.py
+++ b/openff/system/tests/test_combination.py
@@ -6,6 +6,7 @@ from openff.toolkit.topology import Molecule
 from openff.units import unit
 
 from openff.system.components.misc import OFFBioTop
+from openff.system.components.system import System
 from openff.system.stubs import ForceField
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
@@ -26,7 +27,8 @@ class TestSystemCombination(BaseTest):
         openff_sys.positions = mol.conformers[0]._value / 10.0
 
         # Copy and translate atoms by [1, 1, 1]
-        other = deepcopy(openff_sys)
+        other = System()
+        other._inner_data = deepcopy(openff_sys._inner_data)
         other.positions += 1.0 * unit.nanometer
 
         combined = openff_sys + other


### PR DESCRIPTION
### Description
This PR updates the `System` class to follow an "outer/inner" data model in which the internals are hidden away in a pseudo-private inner class and an outer model has some API points for getting/setting pieces of the inner model. This is inspired by the [`Molecule`](https://github.com/SimonBoothroyd/strawman/blob/41cbee89b41b33afa49cbaec9ba28ca4ee5d729b/strawman/molecule.py#L145) class in the "strawman."


### Checklist
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
