### PR TITLE
Fix SMIRNOFF angle handler expression

### DIFF
--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -124,7 +124,7 @@ class SMIRNOFFConstraintHandler(PotentialHandler):
 class SMIRNOFFAngleHandler(PotentialHandler):
 
     name: str = "Angles"
-    expression: str = "1/2 * k * (angle - theta)"
+    expression: str = "1/2 * k * (theta - angle) ** 2"
     independent_variables: Set[str] = {"theta"}
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
     potentials: Dict[PotentialKey, Potential] = dict()


### PR DESCRIPTION
### Description

The expression for the `SMIRNOFFAngleHandler` was missing the power of two. This PR fixes the expresion and changes the order to more closely match the `SMIRNOFFBondHandler` for consistency (i.e. independent D.O.F - parameter).

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
