### PR TITLE
Update models

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
         python -m pytest -v $COV openff/system/tests/ --ignore=openff/system/tests/parmed/
 
     - name: Run ParmEd tests
+      continue-on-error: true
       shell: bash -l {0}
       run: |
         python -m pytest -v $COV openff/system/tests/parmed

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,6 +13,10 @@ dependencies:
   - jax
   - mdtraj
   - ele
+
+    # Python <3.8
+  - typing-extensions
+
     # Testing
   - pytest
   - pytest-cov

--- a/examples/smirnoff_argon.ipynb
+++ b/examples/smirnoff_argon.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "# Look at some ~metadata\n",
-    "vdw.name, vdw.expression, vdw.independent_variables"
+    "vdw.type, vdw.expression, vdw.independent_variables"
    ]
   },
   {

--- a/examples/smirnoff_ethanol.ipynb
+++ b/examples/smirnoff_ethanol.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "# Look at some ~metadata\n",
-    "bonds.name, bonds.expression, bonds.independent_variables"
+    "bonds.type, bonds.expression, bonds.independent_variables"
    ]
   },
   {

--- a/openff/system/components/foyer.py
+++ b/openff/system/components/foyer.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from copy import copy
-from typing import TYPE_CHECKING, Dict, Set, Type
+from typing import TYPE_CHECKING, Dict, Type
 
 from ele import element_from_atomic_number
 from openff.units import unit
@@ -110,9 +110,8 @@ def get_handlers_callable() -> Dict[str, Type[PotentialHandler]]:
 
 
 class FoyerVDWHandler(PotentialHandler):
-    name: str = "atoms"
+    type: str = "atoms"
     expression: str = "4*epsilon*((sigma/r)**12-(sigma/r)**6)"
-    independent_variables: Set[str] = {"r"}
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
     potentials: Dict[PotentialKey, Potential] = dict()
     scale_13: float = 0.0
@@ -138,7 +137,7 @@ class FoyerVDWHandler(PotentialHandler):
     def store_potentials(self, forcefield: "Forcefield") -> None:
         for top_key in self.slot_map:
             atom_params = forcefield.get_parameters(
-                self.name, key=self.slot_map[top_key].id
+                self.type, key=self.slot_map[top_key].id
             )
 
             atom_params = _copy_params(
@@ -151,10 +150,9 @@ class FoyerVDWHandler(PotentialHandler):
 
 
 class FoyerElectrostaticsHandler(PotentialHandler):
-    name: str = "Electrostatics"
+    type: str = "Electrostatics"
     method: str = "PME"
     expression: str = "coul"
-    independent_variables: Set[str] = {"r"}
     charges: Dict[TopologyKey, float] = dict()
     scale_13: float = 0.0
     scale_14: float = 0.5  # TODO: Replace with Foyer API point?
@@ -204,7 +202,7 @@ class FoyerConnectedAtomsHandler(PotentialHandler):
         for _, pot_key in self.slot_map.items():
             try:
                 params = forcefield.get_parameters(
-                    self.name, key=pot_key.id.split(POTENTIAL_KEY_SEPARATOR)
+                    self.type, key=pot_key.id.split(POTENTIAL_KEY_SEPARATOR)
                 )
                 params = self.get_params_with_units(params)
                 self.potentials[pot_key] = Potential(parameters=params)
@@ -225,9 +223,8 @@ class FoyerConnectedAtomsHandler(PotentialHandler):
 
 
 class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler):
-    name: str = "harmonic_bonds"
+    type: str = "harmonic_bonds"
     expression: str = "1/2 * k * (r - length) ** 2"
-    independent_variables: Set[str] = {"r"}
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
     potentials: Dict[PotentialKey, Potential] = dict()
     connection_attribute = "topology_bonds"
@@ -240,9 +237,8 @@ class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerHarmonicAngleHandler(FoyerConnectedAtomsHandler):
-    name: str = "harmonic_angles"
+    type: str = "harmonic_angles"
     expression: str = "0.5 * k * (theta-angle)**2"
-    independent_variables: Set[str] = {"theta"}
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
     potentials: Dict[PotentialKey, Potential] = dict()
     connection_attribute: str = "angles"
@@ -258,13 +254,12 @@ class FoyerHarmonicAngleHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerRBProperHandler(FoyerConnectedAtomsHandler):
-    name: str = "rb_propers"
+    type: str = "rb_propers"
     expression: str = (
         "C0 * cos(phi)**0 + C1 * cos(phi)**1 + "
         "C2 * cos(phi)**2 + C3 * cos(phi)**3 + "
         "C4 * cos(phi)**4 + C5 * cos(phi)**5"
     )
-    independent_variables: Set[str] = {"phi"}
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
     potentials: Dict[PotentialKey, Potential] = dict()
     connection_attribute: str = "propers"
@@ -277,14 +272,13 @@ class FoyerRBProperHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerRBImproperHandler(FoyerRBProperHandler):
-    name: str = "rb_impropers"
+    type: str = "rb_impropers"
     connection_attribute: str = "impropers"
 
 
 class FoyerPeriodicProperHandler(FoyerConnectedAtomsHandler):
-    name: str = "periodic_propers"
+    type: str = "periodic_propers"
     expression: str = "k * (1 + cos(periodicity * phi - phase))"
-    independent_variables: Set[str] = {"phi"}
     connection_attribute: str = "propers"
     raise_on_missing_params: bool = False
 
@@ -300,5 +294,5 @@ class FoyerPeriodicProperHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerPeriodicImproperHandler(FoyerPeriodicProperHandler):
-    name: str = "periodic_impropers"
+    type: str = "periodic_impropers"
     connection_attribute: str = "impropers"

--- a/openff/system/components/foyer.py
+++ b/openff/system/components/foyer.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from foyer.forcefield import Forcefield
     from foyer.topology_graph import TopologyGraph
 
-    from openff.system.components.misc import OFFBioTop
+    from openff.system.components.mdtraj import OFFBioTop
 
 # Is this the safest way to achieve PotentialKey id separation?
 POTENTIAL_KEY_SEPARATOR = "-"
@@ -296,3 +296,15 @@ class FoyerPeriodicProperHandler(FoyerConnectedAtomsHandler):
 class FoyerPeriodicImproperHandler(FoyerPeriodicProperHandler):
     type: str = "periodic_impropers"
     connection_attribute: str = "impropers"
+
+
+class RBTorsionHandler(PotentialHandler):
+    name = "Ryckaert-Bellemans"
+    expression = (
+        "C0 + C1 * (cos(phi - 180)) "
+        "C2 * (cos(phi - 180)) ** 2 + C3 * (cos(phi - 180)) ** 3 "
+        "C4 * (cos(phi - 180)) ** 4 + C5 * (cos(phi - 180)) ** 5 "
+    )
+    # independent_variables: Set[str] = {"C0", "C1", "C2", "C3", "C4", "C5"}
+    slot_map: Dict[TopologyKey, PotentialKey] = dict()
+    potentials: Dict[PotentialKey, Potential] = dict()

--- a/openff/system/components/mdtraj.py
+++ b/openff/system/components/mdtraj.py
@@ -1,34 +1,5 @@
-from typing import Dict, Literal
-
 import mdtraj as md
 from openff.toolkit.topology import Topology
-
-from openff.system.components.potentials import Potential, PotentialHandler
-from openff.system.models import PotentialKey, TopologyKey
-
-
-class BuckinghamvdWHandler(PotentialHandler):
-    type: Literal["Buckingham-6"] = "Buckingham-6"
-    expression: Literal["a*exp(-b*r)-c*r**-6"] = "a*exp(-b*r)-c*r**-6"
-    method: str = "cutoff"
-    cutoff: float = 9.0
-    slot_map: Dict[TopologyKey, PotentialKey] = dict()
-    potentials: Dict[PotentialKey, Potential] = dict()
-    scale_13: float = 0.0
-    scale_14: float = 0.5
-    scale_15: float = 1.0
-
-
-class RBTorsionHandler(PotentialHandler):
-    name = "Ryckaert-Bellemans"
-    expression = (
-        "C0 + C1 * (cos(phi - 180)) "
-        "C2 * (cos(phi - 180)) ** 2 + C3 * (cos(phi - 180)) ** 3 "
-        "C4 * (cos(phi - 180)) ** 4 + C5 * (cos(phi - 180)) ** 5 "
-    )
-    # independent_variables: Set[str] = {"C0", "C1", "C2", "C3", "C4", "C5"}
-    slot_map: Dict[TopologyKey, PotentialKey] = dict()
-    potentials: Dict[PotentialKey, Potential] = dict()
 
 
 class OFFBioTop(Topology):

--- a/openff/system/components/misc.py
+++ b/openff/system/components/misc.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set
+from typing import Dict, Literal
 
 import mdtraj as md
 from openff.toolkit.topology import Topology
@@ -8,9 +8,8 @@ from openff.system.models import PotentialKey, TopologyKey
 
 
 class BuckinghamvdWHandler(PotentialHandler):
-    name = "Buckingham-6"
-    expression = "A * exp(-B *r) - C * r ** -6"
-    independent_variables: Set[str] = {"r"}
+    type: Literal["Buckingham-6"] = "Buckingham-6"
+    expression: Literal["a*exp(-b*r)-c*r**-6"] = "a*exp(-b*r)-c*r**-6"
     method: str = "cutoff"
     cutoff: float = 9.0
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
@@ -27,7 +26,7 @@ class RBTorsionHandler(PotentialHandler):
         "C2 * (cos(phi - 180)) ** 2 + C3 * (cos(phi - 180)) ** 3 "
         "C4 * (cos(phi - 180)) ** 4 + C5 * (cos(phi - 180)) ** 5 "
     )
-    independent_variables: Set[str] = {"C0", "C1", "C2", "C3", "C4", "C5"}
+    # independent_variables: Set[str] = {"C0", "C1", "C2", "C3", "C4", "C5"}
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
     potentials: Dict[PotentialKey, Potential] = dict()
 

--- a/openff/system/components/nonbonded.py
+++ b/openff/system/components/nonbonded.py
@@ -1,0 +1,16 @@
+from typing import Dict, Literal
+
+from openff.system.components.potentials import Potential, PotentialHandler
+from openff.system.models import PotentialKey, TopologyKey
+
+
+class BuckinghamvdWHandler(PotentialHandler):
+    type: Literal["Buckingham-6"] = "Buckingham-6"
+    expression: Literal["a*exp(-b*r)-c*r**-6"] = "a*exp(-b*r)-c*r**-6"
+    method: str = "cutoff"
+    cutoff: float = 9.0
+    slot_map: Dict[TopologyKey, PotentialKey] = dict()
+    potentials: Dict[PotentialKey, Potential] = dict()
+    scale_13: float = 0.0
+    scale_14: float = 0.5
+    scale_15: float = 1.0

--- a/openff/system/components/nonbonded.py
+++ b/openff/system/components/nonbonded.py
@@ -1,4 +1,6 @@
-from typing import Dict, Literal
+from typing import Dict
+
+from typing_extensions import Literal
 
 from openff.system.components.potentials import Potential, PotentialHandler
 from openff.system.models import PotentialKey, TopologyKey

--- a/openff/system/components/potentials.py
+++ b/openff/system/components/potentials.py
@@ -9,7 +9,7 @@ from openff.system.models import DefaultModel, PotentialKey, TopologyKey
 from openff.system.types import ArrayQuantity, FloatQuantity
 
 if TYPE_CHECKING:
-    from openff.system.components.misc import OFFBioTop
+    from openff.system.components.mdtraj import OFFBioTop
 
 
 class Potential(DefaultModel):

--- a/openff/system/components/potentials.py
+++ b/openff/system/components/potentials.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Dict, List, Set, Union
+import ast
+from typing import TYPE_CHECKING, Dict, List, Set
 
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
 from openff.utilities.utils import requires_package
-from pydantic import validator
+from pydantic import Field, validator
 
-from openff.system.exceptions import InvalidExpressionError
 from openff.system.models import DefaultModel, PotentialKey, TopologyKey
 from openff.system.types import ArrayQuantity, FloatQuantity
 
@@ -15,8 +15,7 @@ if TYPE_CHECKING:
 class Potential(DefaultModel):
     """Base class for storing applied parameters"""
 
-    # ... Dict[str, FloatQuantity] = dict()
-    parameters: Dict = dict()
+    parameters: Dict[str, FloatQuantity] = dict()
 
     @validator("parameters")
     def validate_parameters(cls, v):
@@ -31,20 +30,29 @@ class Potential(DefaultModel):
 class PotentialHandler(DefaultModel):
     """Base class for storing parametrized force field data"""
 
-    name: str
-    expression: str
-    independent_variables: Union[str, Set[str]]
-    slot_map: Dict[TopologyKey, PotentialKey] = dict()
-    potentials: Dict[PotentialKey, Potential] = dict()
+    type: str = Field(..., description="The type of potentials this handler stores.")
+    expression: str = Field(
+        ...,
+        description="The analytical expression governing the potentials in this handler.",
+    )
+    slot_map: Dict[TopologyKey, PotentialKey] = Field(
+        dict(),
+        description="A mapping between TopologyKey objects and PotentialKey objects.",
+    )
+    potentials: Dict[PotentialKey, Potential] = Field(
+        dict(),
+        description="A mapping between PotentialKey objects and Potential objects.",
+    )
 
-    # Pydantic silently casts some types (int, float, Decimal) to str
-    # in models that expect str; this may be updates, see #1098
-    @validator("expression", pre=True)
-    def is_valid_expr(cls, val):
-        if isinstance(val, str):
-            return val
-        else:
-            raise InvalidExpressionError
+    @property
+    def independent_variables(self) -> Set[str]:
+        vars_in_potentials = set([*self.potentials.values()][0].parameters.keys())
+        vars_in_expression = {
+            node.id
+            for node in ast.walk(ast.parse(self.expression))
+            if isinstance(node, ast.Name)
+        }
+        return vars_in_expression - vars_in_potentials
 
     def store_matches(
         self,

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -8,6 +8,7 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
     ConstraintHandler,
     ImproperTorsionHandler,
     LibraryChargeHandler,
+    ParameterHandler,
     ProperTorsionHandler,
     vdWHandler,
 )
@@ -30,14 +31,8 @@ kcal_mol_radians = kcal_mol / omm_unit.radian ** 2
 class SMIRNOFFPotentialHandler(PotentialHandler):
     pass
 
-
-class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
-
-    type: Literal["Bonds"] = "Bonds"
-    expression: Literal["k/2*(r-length)**2"] = "k/2*(r-length)**2"
-
     def store_matches(
-        self, parameter_handler: BondHandler, topology: OFFBioTop
+        self, parameter_handler: ParameterHandler, topology: OFFBioTop
     ) -> None:
         """
         Populate self.slot_map with key-val pairs of slots
@@ -51,6 +46,12 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
             topology_key = TopologyKey(atom_indices=key)
             potential_key = PotentialKey(id=val.parameter_type.smirks)
             self.slot_map[topology_key] = potential_key
+
+
+class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
+
+    type: Literal["Bonds"] = "Bonds"
+    expression: Literal["k/2*(r-length)**2"] = "k/2*(r-length)**2"
 
     def store_potentials(self, parameter_handler: BondHandler) -> None:
         """
@@ -125,22 +126,6 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
 
     type: Literal["Angles"] = "Angles"
     expression: Literal["k/2*(theta-angle)**2"] = "k/2*(theta-angle)**2"
-
-    def store_matches(
-        self,
-        parameter_handler: AngleHandler,
-        topology: OFFBioTop,
-    ) -> None:
-        """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
-
-        """
-        matches = parameter_handler.find_matches(topology)
-        for key, val in matches.items():
-            topology_key = TopologyKey(atom_indices=key)
-            potential_key = PotentialKey(id=val.parameter_type.smirks)
-            self.slot_map[topology_key] = potential_key
 
     def store_potentials(self, parameter_handler: AngleHandler) -> None:
         """
@@ -279,22 +264,6 @@ class SMIRNOFFvdWHandler(SMIRNOFFPotentialHandler):
             raise UnsupportedCutoffMethodError(f"vdW method {v} not supported")
         return v
 
-    def store_matches(
-        self,
-        parameter_handler: vdWHandler,
-        topology: OFFBioTop,
-    ) -> None:
-        """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
-
-        """
-        matches = parameter_handler.find_matches(topology)
-        for key, val in matches.items():
-            topology_key = TopologyKey(atom_indices=key)
-            potential_key = PotentialKey(id=val.parameter_type.smirks)
-            self.slot_map[topology_key] = potential_key
-
     def store_potentials(self, parameter_handler: vdWHandler) -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
@@ -373,17 +342,6 @@ class SMIRNOFFLibraryChargeHandler(  # type: ignore[misc]
 
     type: str = "LibraryCharges"
 
-    def store_matches(
-        self,
-        parameter_handler: LibraryChargeHandler,
-        topology: OFFBioTop,
-    ) -> None:
-        matches = parameter_handler.find_matches(topology)
-        for key, val in matches.items():
-            top_key = TopologyKey(atom_indices=key)
-            pot_key = PotentialKey(id=val.parameter_type.smirks)
-            self.slot_map[top_key] = pot_key
-
     def store_potentials(self, parameter_handler: LibraryChargeHandler) -> None:
         if self.potentials:
             self.potentials = dict()
@@ -405,17 +363,6 @@ class SMIRNOFFChargeIncrementHandler(  # type: ignore[misc]
     type: str = "ChargeIncrements"
     partial_charge_method: str = "AM1-Mulliken"
     potentials: Dict[PotentialKey, Potential] = dict()
-
-    def store_matches(
-        self,
-        parameter_handler: ChargeIncrementModelHandler,
-        topology: OFFBioTop,
-    ) -> None:
-        matches = parameter_handler.find_matches(topology)
-        for key, val in matches.items():
-            top_key = TopologyKey(atom_indices=key)
-            pot_key = PotentialKey(id=val.parameter_type.smirks)
-            self.slot_map[top_key] = pot_key
 
     def store_potentials(self, parameter_handler: ChargeIncrementModelHandler) -> None:
         if self.potentials:

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -309,9 +309,9 @@ class SMIRNOFFvdWHandler(SMIRNOFFPotentialHandler):
 
 class SMIRNOFFElectrostaticsMetadataMixin(DefaultModel):
 
-    type: str = "Electrostatics"
-    expression: str = "coul"
-    method: Literal["pme", "cuotff", "reaction-field"]
+    type: Literal["Electrostatics"] = "Electrostatics"
+    expression: Literal["coul"] = "coul"
+    method: Literal["pme", "cutoff", "reaction-field"]
     cutoff: FloatQuantity["angstrom"] = 9.0  # type: ignore
     charge_map: Dict[TopologyKey, float] = dict()
     scale_13: float = Field(
@@ -346,14 +346,13 @@ class SMIRNOFFElectrostaticsMetadataMixin(DefaultModel):
 
 
 class SMIRNOFFLibraryChargeHandler(  # type: ignore[misc]
-    # SMIRNOFFElectrostaticsMetadataMixin,
     SMIRNOFFPotentialHandler,
 ):
 
-    type: str = "LibraryCharges"
+    type: Literal["LibraryCharges"] = "LibraryCharges"
     # TODO: This should be specified by a parent class and not required (or event allowed)
     # to be specified here
-    expression: str = "coul"
+    expression: Literal["coul"] = "coul"
 
     def store_potentials(self, parameter_handler: LibraryChargeHandler) -> None:
         if self.potentials:
@@ -369,11 +368,13 @@ class SMIRNOFFLibraryChargeHandler(  # type: ignore[misc]
 
 
 class SMIRNOFFChargeIncrementHandler(  # type: ignore[misc]
-    SMIRNOFFElectrostaticsMetadataMixin,
     SMIRNOFFPotentialHandler,
 ):
 
-    type: str = "ChargeIncrements"
+    type: Literal["ChargeIncrements"] = "ChargeIncrements"
+    # TODO: This should be specified by a parent class and not required (or event allowed)
+    # to be specified here
+    expression: Literal["coul"] = "coul"
     partial_charge_method: str = "AM1-Mulliken"
     potentials: Dict[PotentialKey, Potential] = dict()
 
@@ -394,9 +395,7 @@ class SMIRNOFFChargeIncrementHandler(  # type: ignore[misc]
 
 class ElectrostaticsMetaHandler(SMIRNOFFElectrostaticsMetadataMixin):
 
-    type: Literal["Electrostatics"] = "Electrostatics"
-    expression: Literal["coul"] = "coul"
-    method: Literal["cutoff", "pme"] = "pme"
+    method: Literal["pme", "cutoff", "reaction-field"]
     charges: Dict = dict()  # type
     cache: Dict = dict()  # Dict[str: Dict[str, FloatQuantity["elementary_charge"]]]
 

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -16,7 +16,7 @@ from openff.units import unit
 from pydantic import validator
 from simtk import unit as omm_unit
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.potentials import Potential, PotentialHandler
 from openff.system.exceptions import UnsupportedCutoffMethodError
 from openff.system.models import DefaultModel, PotentialKey, TopologyKey

--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 from pydantic import Field, validator
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.potentials import PotentialHandler
 from openff.system.exceptions import (
     InternalInconsistencyError,

--- a/openff/system/interop/internal/gromacs.py
+++ b/openff/system/interop/internal/gromacs.py
@@ -5,7 +5,7 @@ import ele
 import numpy as np
 from openff.units import unit
 
-from openff.system.components.misc import (
+from openff.system.components.mdtraj import (
     _iterate_angles,
     _iterate_impropers,
     _iterate_pairs,

--- a/openff/system/interop/internal/lammps.py
+++ b/openff/system/interop/internal/lammps.py
@@ -291,7 +291,7 @@ def _write_bonds(lmp_file: IO, openff_sys: System):
 
 
 def _write_angles(lmp_file: IO, openff_sys: System):
-    from openff.system.components.misc import _iterate_angles, _store_bond_partners
+    from openff.system.components.mdtraj import _iterate_angles, _store_bond_partners
 
     _store_bond_partners(openff_sys.topology.mdtop)  # type: ignore[union-attr]
 
@@ -321,7 +321,7 @@ def _write_angles(lmp_file: IO, openff_sys: System):
 
 
 def _write_propers(lmp_file: IO, openff_sys: System):
-    from openff.system.components.misc import _iterate_propers, _store_bond_partners
+    from openff.system.components.mdtraj import _iterate_propers, _store_bond_partners
 
     _store_bond_partners(openff_sys.topology.mdtop)  # type: ignore[union-attr]
 
@@ -353,7 +353,7 @@ def _write_propers(lmp_file: IO, openff_sys: System):
 
 
 def _write_impropers(lmp_file: IO, openff_sys: System):
-    from openff.system.components.misc import _iterate_impropers, _store_bond_partners
+    from openff.system.components.mdtraj import _iterate_impropers, _store_bond_partners
 
     _store_bond_partners(openff_sys.topology.mdtop)  # type: ignore[union-attr]
 

--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -413,7 +413,7 @@ def from_openmm(topology=None, system=None, positions=None, box_vectors=None):
     if topology:
         import mdtraj as md
 
-        from openff.system.components.misc import OFFBioTop
+        from openff.system.components.mdtraj import OFFBioTop
 
         mdtop = md.Topology.from_openmm(topology)
         top = OFFBioTop.from_openmm(topology)

--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -437,7 +437,7 @@ def _convert_nonbonded_force(force):
     )
 
     vdw_handler = SMIRNOFFvdWHandler()
-    electrostatics = ElectrostaticsMetaHandler()
+    electrostatics = ElectrostaticsMetaHandler(method="pme")
 
     n_parametrized_particles = force.getNumParticles()
 
@@ -457,6 +457,17 @@ def _convert_nonbonded_force(force):
 
     vdw_handler.cutoff = force.getCutoffDistance()
     electrostatics.cutoff = force.getCutoffDistance()
+
+    if force.getNonbondedMethod() == openmm.NonbondedForce.PME:
+        electrostatics.method = "pme"
+    elif force.getNonbondedMethod() in {
+        openmm.NonbondedForce.CutoffPeriodic,
+        openmm.NonbondedForce.CutoffNonPeriodic,
+    }:
+        # TODO: Store reaction-field dielectric
+        electrostatics.method = "reactionfield"
+    elif force.getNonbondedMethod() == openmm.NonbondedForce.NoCutoff:
+        raise Exception("NonbondedMethod NoCutoff is not supported")
 
     return vdw_handler, electrostatics
 

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -250,7 +250,7 @@ def _from_parmed(cls, structure) -> "System":
 
     from openff.toolkit.topology import Molecule
 
-    from openff.system.components.misc import OFFBioTop
+    from openff.system.components.mdtraj import OFFBioTop
 
     if structure.topology is not None:
         mdtop = md.Topology.from_openmm(structure.topology)

--- a/openff/system/models.py
+++ b/openff/system/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Tuple
 
 from openff.units import unit
 from pydantic import BaseModel, Field
@@ -17,8 +17,7 @@ class DefaultModel(BaseModel):
 
 
 class TopologyKey(DefaultModel):
-    # Should be Tuple[int], see issues #495
-    atom_indices: Sequence[int] = Field(
+    atom_indices: Tuple[int, ...] = Field(
         tuple(), description="The indices of the atoms occupied by this interaction"
     )
     mult: Optional[int] = Field(

--- a/openff/system/stubs.py
+++ b/openff/system/stubs.py
@@ -98,7 +98,7 @@ def to_openff_system(
             scale_13=self["Electrostatics"].scale13,
             scale_14=self["Electrostatics"].scale14,
             scale_15=self["Electrostatics"].scale15,
-            method=self["Electrostatics"].method,
+            method=self["Electrostatics"].method.lower(),
             cutoff=self["Electrostatics"].cutoff,
         )
         if "ToolkitAM1BCC" in self.registered_parameter_handlers:
@@ -242,7 +242,7 @@ def create_vdw_potential_handler(
         scale_14=self.scale14,
         scale_15=self.scale15,
         cutoff=self.cutoff,
-        method=self.method,
+        method=self.method.lower(),
         switch_width=self.switch_width,
     )
     handler.store_matches(parameter_handler=self, topology=topology)

--- a/openff/system/stubs.py
+++ b/openff/system/stubs.py
@@ -30,6 +30,15 @@ from openff.system.components.smirnoff import (
 from openff.system.components.system import System
 from openff.system.exceptions import InvalidTopologyError
 
+_MAPPING = {
+    ConstraintHandler: SMIRNOFFConstraintHandler,
+    BondHandler: SMIRNOFFBondHandler,
+    AngleHandler: SMIRNOFFAngleHandler,
+    ProperTorsionHandler: SMIRNOFFProperTorsionHandler,
+    ImproperTorsionHandler: SMIRNOFFImproperTorsionHandler,
+    vdWHandler: SMIRNOFFvdWHandler,
+}
+
 
 def to_openff_system(
     self,
@@ -267,15 +276,6 @@ def _check_supported_handlers(forcefield: ForceField):
 
         raise SMIRNOFFHandlersNotImplementedError(unsupported)
 
-
-mapping = {
-    ConstraintHandler: SMIRNOFFConstraintHandler,
-    BondHandler: SMIRNOFFBondHandler,
-    AngleHandler: SMIRNOFFAngleHandler,
-    ProperTorsionHandler: SMIRNOFFProperTorsionHandler,
-    ImproperTorsionHandler: SMIRNOFFImproperTorsionHandler,
-    vdWHandler: SMIRNOFFvdWHandler,
-}
 
 BondHandler.create_potential = create_bond_potential_handler
 AngleHandler.create_potential = create_angle_potential_handler

--- a/openff/system/stubs.py
+++ b/openff/system/stubs.py
@@ -15,7 +15,7 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
     vdWHandler,
 )
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.smirnoff import (
     ElectrostaticsMetaHandler,
     SMIRNOFFAngleHandler,

--- a/openff/system/tests/base_test.py
+++ b/openff/system/tests/base_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 from openff.toolkit.topology.molecule import Molecule
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.stubs import ForceField
 from openff.system.tests.utils import top_from_smiles
 from openff.system.utils import get_test_file_path

--- a/openff/system/tests/energy_tests/gromacs.py
+++ b/openff/system/tests/energy_tests/gromacs.py
@@ -54,13 +54,13 @@ def _write_mdp_file(openff_sys: "System"):
             coul_method = coul_handler.method  # type: ignore[attr-defined]
             coul_cutoff = coul_handler.cutoff.m_as(unit.nanometer)  # type: ignore[attr-defined]
             coul_cutoff = round(coul_cutoff, 4)
-            if coul_method in ["Cut-off", "cutoff"]:
+            if coul_method == "cutoff":
                 mdp_file.write("coulombtype = Cut-off\n")
                 mdp_file.write(f"rcoulomb = {coul_cutoff}\n")
-            elif coul_method == "PME":
+            elif coul_method == "pme":
                 mdp_file.write("coulombtype = PME\n")
                 mdp_file.write(f"rcoulomb = {coul_cutoff}\n")
-            elif coul_method == "reaction-field":
+            elif coul_method == "reactionfield":
                 mdp_file.write(f"rcoulomb = {coul_cutoff}\n")
                 mdp_file.write(f"rcoulomb = {coul_cutoff}\n")
             else:
@@ -75,7 +75,7 @@ def _write_mdp_file(openff_sys: "System"):
             vdw_cutoff = round(vdw_cutoff, 4)
             if vdw_method == "cutoff":
                 mdp_file.write("vdwtype = cutoff\n")
-            elif vdw_method == "PME":
+            elif vdw_method == "pme":
                 mdp_file.write("vdwtype = PME\n")
             else:
                 raise UnsupportedExportError(f"vdW method {vdw_method} not supported")

--- a/openff/system/tests/energy_tests/gromacs.py
+++ b/openff/system/tests/energy_tests/gromacs.py
@@ -96,7 +96,7 @@ def _write_mdp_file(openff_sys: "System"):
             if num_constraints == 0:
                 mdp_file.write("constraints = none\n")
             else:
-                from openff.system.components.misc import _get_num_h_bonds
+                from openff.system.components.mdtraj import _get_num_h_bonds
 
                 num_h_bonds = _get_num_h_bonds(openff_sys.topology.mdtop)  # type: ignore[union-attr]
                 num_bonds = len(openff_sys["Bonds"].slot_map)

--- a/openff/system/tests/energy_tests/test_energies.py
+++ b/openff/system/tests/energy_tests/test_energies.py
@@ -11,7 +11,7 @@ from simtk import openmm
 from simtk import unit as simtk_unit
 from simtk.openmm import app
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.openmm import (
     _get_openmm_energies,

--- a/openff/system/tests/test_buckingham.py
+++ b/openff/system/tests/test_buckingham.py
@@ -9,7 +9,8 @@ from openff.utilities.testing import skip_if_missing
 from scipy.constants import Avogadro
 from simtk import unit as simtk_unit
 
-from openff.system.components.misc import BuckinghamvdWHandler, OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
+from openff.system.components.nonbonded import BuckinghamvdWHandler
 from openff.system.components.potentials import Potential
 from openff.system.components.smirnoff import ElectrostaticsMetaHandler
 from openff.system.exceptions import GMXMdrunError

--- a/openff/system/tests/test_combination.py
+++ b/openff/system/tests/test_combination.py
@@ -5,7 +5,7 @@ import numpy as np
 from openff.toolkit.topology import Molecule
 from openff.units import unit
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.system import System
 from openff.system.stubs import ForceField
 from openff.system.tests.base_test import BaseTest

--- a/openff/system/tests/test_external.py
+++ b/openff/system/tests/test_external.py
@@ -7,7 +7,7 @@ from openff.units import unit
 from simtk import openmm
 from simtk.unit import nanometer as nm
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.stubs import ForceField
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.energy_tests.openmm import (

--- a/openff/system/tests/test_foyer.py
+++ b/openff/system/tests/test_foyer.py
@@ -7,7 +7,7 @@ from openff.utilities.testing import skip_if_missing
 from openff.utilities.utils import has_pkg
 from simtk import unit as simtk_unit
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.tests.base_test import BaseTest
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
 

--- a/openff/system/tests/test_interop/test_lammps.py
+++ b/openff/system/tests/test_interop/test_lammps.py
@@ -4,7 +4,7 @@ import pytest
 from openff.toolkit.topology import Molecule
 from simtk import unit as omm_unit
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.lammps import (
     _write_lammps_input,

--- a/openff/system/tests/test_misc.py
+++ b/openff/system/tests/test_misc.py
@@ -1,7 +1,7 @@
 import mdtraj as md
 from openff.toolkit.topology import Molecule
 
-from openff.system.components.misc import (
+from openff.system.components.mdtraj import (
     _get_num_h_bonds,
     _iterate_pairs,
     _iterate_propers,

--- a/openff/system/tests/test_potential.py
+++ b/openff/system/tests/test_potential.py
@@ -1,4 +1,3 @@
-import pydantic
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff.parameters import AngleHandler, BondHandler
@@ -14,15 +13,11 @@ from openff.system.tests.base_test import BaseTest
 class TestBondPotentialHandler(BaseTest):
     def test_dummy_potential_handler(self):
         handler = PotentialHandler(
-            name="foo", expression="m*x+b", independent_variables="x"
+            type="foo",
+            expression="m*x+b",
         )
+        assert handler.type == "foo"
         assert handler.expression == "m*x+b"
-
-        # Pydantic silently casts some types (int, float, Decimal) to str
-        # in models that expect str; this test checks that the validator's
-        # pre=True argument works;
-        with pytest.raises(pydantic.ValidationError):
-            PotentialHandler(name="foo", expression=1, independent_variables="x")
 
     def test_bond_potential_handler(self):
         top = OFFBioTop.from_molecules(Molecule.from_smiles("O=O"))

--- a/openff/system/tests/test_potential.py
+++ b/openff/system/tests/test_potential.py
@@ -4,7 +4,7 @@ from openff.toolkit.typing.engines.smirnoff.parameters import AngleHandler, Bond
 from openff.units import unit
 from simtk import unit as omm_unit
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.potentials import PotentialHandler
 from openff.system.models import TopologyKey
 from openff.system.tests.base_test import BaseTest

--- a/openff/system/tests/test_rb_torsions.py
+++ b/openff/system/tests/test_rb_torsions.py
@@ -5,7 +5,7 @@ from openff.units import unit
 from openff.utilities.testing import skip_if_missing
 from openff.utilities.utils import has_pkg
 
-from openff.system.components.misc import RBTorsionHandler
+from openff.system.components.foyer import RBTorsionHandler
 from openff.system.components.potentials import Potential
 from openff.system.models import PotentialKey, TopologyKey
 from openff.system.stubs import ForceField

--- a/openff/system/tests/test_residue.py
+++ b/openff/system/tests/test_residue.py
@@ -3,7 +3,7 @@ import pytest
 from openff.toolkit.topology import Molecule
 from simtk.openmm import app
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.stubs import ForceField
 from openff.system.tests.energy_tests.openmm import get_openmm_energies
 from openff.system.utils import get_test_file_path

--- a/openff/system/tests/test_stubs.py
+++ b/openff/system/tests/test_stubs.py
@@ -4,7 +4,7 @@ from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.utils import get_data_file_path
 from openff.utilities.testing import skip_if_missing
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.exceptions import (
     InvalidTopologyError,
     SMIRNOFFHandlersNotImplementedError,

--- a/openff/system/tests/utils.py
+++ b/openff/system/tests/utils.py
@@ -4,7 +4,7 @@ from openff.toolkit.topology import Molecule
 from simtk import openmm
 from simtk import unit as omm_unit
 
-from openff.system.components.misc import OFFBioTop
+from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.system import System
 from openff.system.exceptions import InterMolEnergyComparisonError
 
@@ -25,7 +25,7 @@ def top_from_smiles(
 
     Returns
     -------
-    top : opennff.system.components.misc.OFFBioTop
+    top : opennff.system.components.mdtraj.OFFBioTop
         A single-molecule, gas phase-like topology
 
     """


### PR DESCRIPTION
### Description
Refactoring/cleanup some code based on technical feedback from @SimonBoothroyd 

- [x] Use `Literal`s in Pydantic models
- [x] `PotentialHandler.name` -> `PotentialHandler.type`
- [ ] Explicitly use `Field` where possible
  - [ ] Add descriptions
  - [ ] Other things that are optional but useful?
 - [ ] Try out `sphinx-pydantic`
 - [x] Make `PotentialHandler.expression` a Literal
 - [x] Make `PotentialHandler.independent_variables` a property, not a field
 - [ ] Remove duplicated code in `openff/system/components/smirnoff.py`
   - [ ] Try out `GenericModel`?
- [ ] Write more validators
  - [ ] `PotentialHandler.parameters` (just to make sure the names of the parameters are actually in the expressions)
  - [ ] Make sure that slot_map and potentials are self-consistent
 - [ ] Fix L323 in `smirnoff.py`
 - [x] `SMIRNOFFElectrostaticsMetadataMixin.method` validator could be rewritten as a Literal
    - [ ]  Look into if the `Literal` class can do some string comparison
  - [x] Split out contents of `misc.py` into more explicitly targeted modules
- [ ] Make `SMIRNOFFPotentialHandler.from_toolkit` class methods
- [ ] Use `SMIRNOFFPotentialHandler.from_toolkit` class methods in `to_openff_system`
