### PR TITLE
Add installation docs

### DIFF
--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
   - conda-forge
-  - bioconda
 dependencies:
     # Base depends
   - python

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -1,4 +1,4 @@
-name: test
+name: openff-system-minimal-env
 channels:
   - conda-forge
 dependencies:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,4 +1,4 @@
-name: test
+name: openff-system-env
 channels:
   - conda-forge
   - bioconda

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum.
 
+```{toctree}
+---
+caption: Installation
+---
+installation.md
+```
 
 ```{toctree}
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,55 @@
+# Installation
+
+These instructions are likely in flux. If something looks out of date or is not working, please raise an issue.
+
+## Install dependencies
+
+Until a conda package is live, the core dependencies are listed in `devtools/conda-envs/minimal_env.yaml` and optional dependencies can be found in `devtools/conda-envs/test_env.yaml`.
+
+Required dependencies:
+  - python
+  - pip
+  - pydantic
+  - pint
+  - openmm
+  - openff-toolkit
+  - jax
+  - mdtraj
+  - ele
+  - `openff-units`
+  - `openff-utilities`
+
+Note that the last two packages are currently unrelreased and must be installed as development builds:
+
+```shell
+# From inside a conda environment
+pip install git+git://github.com/mattwthompson/openff-units.git
+pip install git+git://github.com/mattwthompson/openff-utilities.git
+```
+
+Optional/test/dev dependencies:
+  - pytest
+  - pytest-cov
+  - codecov
+  - nbval
+  - mypy
+  - unyt
+  - intermol
+  - gromacs >=2021
+  - lammps
+  - mbuild
+  - foyer>=0.8.0
+
+If portions of the API that require optional dependencies are called while some of those dependencies are not available, an informative error message should be provided. requiring an optional dependency is dependtest d
+
+All packages are assumed to be at their latest version. In particular, compatibility with older versions of the OpenFF Toolkit (i.e. versions 0.9.0 and older) are not guaranteed.
+
+All packages (with the exceptions of GROMACS via `bioconda`, `openff-units`, and `openff-utilities` described above) are available on `conda-forge` and it assumed that `conda` is used to install them. Most are also available on PyPI via `pip`; while this method of installation is likely to work, it is not currently tested.
+
+## Install the package
+
+Until a conda package is live, the package must be installed locally. After cloning the repo:
+
+```shell
+python -m pip install -e .
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ These instructions are likely in flux. If something looks out of date or is not 
 
 ## Install dependencies
 
-Until a conda package is live, the core dependencies are listed in `devtools/conda-envs/minimal_env.yaml` and optional dependencies can be found in `devtools/conda-envs/test_env.yaml`.
+Until a conda package is live, the core dependencies are listed in `devtools/conda-envs/test_env.yaml` and optional dependencies can be found in `devtools/conda-envs/minimal_env.yaml`.
 
 Required dependencies:
   - python
@@ -22,7 +22,7 @@ Required dependencies:
 Note that the last two packages are currently unrelreased and must be installed as development builds:
 
 ```shell
-# From inside a conda environment
+# In an activated conda environment
 pip install git+git://github.com/mattwthompson/openff-units.git
 pip install git+git://github.com/mattwthompson/openff-utilities.git
 ```
@@ -40,7 +40,7 @@ Optional/test/dev dependencies:
   - mbuild
   - foyer>=0.8.0
 
-If portions of the API that require optional dependencies are called while some of those dependencies are not available, an informative error message should be provided. requiring an optional dependency is dependtest d
+If portions of the API that require optional dependencies are called while some of those dependencies are not available, an informative error message should be provided.
 
 All packages are assumed to be at their latest version. In particular, compatibility with older versions of the OpenFF Toolkit (i.e. versions 0.9.0 and older) are not guaranteed.
 


### PR DESCRIPTION
### Description
This PR adds long-overdue installation docs. The docs probably don't render right now, please refer only do the Markdown source.

@umesh-timalsina @justinGilmer I wonder if anything else stuck out to you as pain points when you were installing development builds recently? I wrote up the major sore points that came to mind personally - please let me know what I may be missing.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
