### PR TITLE
Make SMIRNOFFPotentialHandler.from_toolkit class methods

### DIFF
--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -1,15 +1,11 @@
-from typing import Dict
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type, TypeVar, Union
 
 from openff.toolkit.typing.engines.smirnoff.forcefield import ForceField
 from openff.toolkit.typing.engines.smirnoff.parameters import (
-    AngleHandler,
-    BondHandler,
     ChargeIncrementModelHandler,
     ConstraintHandler,
-    ImproperTorsionHandler,
     LibraryChargeHandler,
     ParameterHandler,
-    ProperTorsionHandler,
     vdWHandler,
 )
 from openff.units import unit
@@ -17,7 +13,6 @@ from pydantic import Field
 from simtk import unit as omm_unit
 from typing_extensions import Literal
 
-from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.potentials import Potential, PotentialHandler
 from openff.system.models import DefaultModel, PotentialKey, TopologyKey
 from openff.system.types import FloatQuantity
@@ -27,10 +22,27 @@ kcal_mol = omm_unit.kilocalorie_per_mole
 kcal_mol_angstroms = kcal_mol / omm_unit.angstrom ** 2
 kcal_mol_radians = kcal_mol / omm_unit.radian ** 2
 
+if TYPE_CHECKING:
+    from openff.toolkit.topology.topology import Topology
+    from openff.toolkit.typing.engines.smirnoff.parameters import (
+        AngleHandler,
+        BondHandler,
+        ImproperTorsionHandler,
+        ProperTorsionHandler,
+    )
+
+    from openff.system.components.mdtraj import OFFBioTop
+
+
+T = TypeVar("T", bound="SMIRNOFFPotentialHandler")
+T_ = TypeVar("T_", bound="PotentialHandler")
+
 
 class SMIRNOFFPotentialHandler(PotentialHandler):
     def store_matches(
-        self, parameter_handler: ParameterHandler, topology: OFFBioTop
+        self,
+        parameter_handler: ParameterHandler,
+        topology: Union["Topology", "OFFBioTop"],
     ) -> None:
         """
         Populate self.slot_map with key-val pairs of slots
@@ -47,13 +59,29 @@ class SMIRNOFFPotentialHandler(PotentialHandler):
             potential_key = PotentialKey(id=val.parameter_type.smirks)
             self.slot_map[topology_key] = potential_key
 
+    @classmethod
+    def from_toolkit(
+        cls: Type[T],
+        parameter_handler: T_,
+        topology: "Topology",
+    ) -> T:
+        """
+        Create a SMIRNOFFAngleHandler from toolkit data.
+
+        """
+        handler = cls()
+        handler.store_matches(parameter_handler=parameter_handler, topology=topology)
+        handler.store_potentials(parameter_handler=parameter_handler)
+
+        return handler
+
 
 class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
 
     type: Literal["Bonds"] = "Bonds"
     expression: Literal["k/2*(r-length)**2"] = "k/2*(r-length)**2"
 
-    def store_potentials(self, parameter_handler: BondHandler) -> None:
+    def store_potentials(self, parameter_handler: "BondHandler") -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
         identifiers and their associated Potential objects
@@ -72,6 +100,33 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
             )
             self.potentials[potential_key] = potential
 
+    @classmethod
+    def from_toolkit(
+        cls: Type[T],
+        topology: "Topology",
+        bond_handler: "BondHandler",
+        constraint_handler: Optional[T] = None,
+    ) -> Tuple[T, Optional[T]]:
+        """
+        Create a SMIRNOFFBondHandler from toolkit data.
+
+        """
+        handler = cls(type="Bonds", expression="k/2*(r-length)**2")
+        handler.store_matches(parameter_handler=bond_handler, topology=topology)
+        handler.store_potentials(parameter_handler=bond_handler)
+
+        if constraint_handler:
+            constraints = SMIRNOFFConstraintHandler()
+            constraints.store_constraints(
+                parameter_handler=constraint_handler,
+                topology=topology,
+                bond_handler=bond_handler,
+            )
+        else:
+            constraints = None  # type: ignore[assignment]
+
+        return handler, constraints
+
 
 class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
 
@@ -85,7 +140,7 @@ class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
     def store_constraints(
         self,
         parameter_handler: ConstraintHandler,
-        topology: OFFBioTop,
+        topology: "OFFBioTop",
         bond_handler: SMIRNOFFBondHandler = None,
     ) -> None:
 
@@ -127,7 +182,7 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
     type: Literal["Angles"] = "Angles"
     expression: Literal["k/2*(theta-angle)**2"] = "k/2*(theta-angle)**2"
 
-    def store_potentials(self, parameter_handler: AngleHandler) -> None:
+    def store_potentials(self, parameter_handler: "AngleHandler") -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
         identifiers and their associated Potential objects
@@ -146,6 +201,22 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
             )
             self.potentials[potential_key] = potential
 
+    @classmethod
+    def from_toolkit(
+        cls: Type[T],
+        parameter_handler: "AngleHandler",
+        topology: "Topology",
+    ) -> T:
+        """
+        Create a SMIRNOFFAngleHandler from toolkit data.
+
+        """
+        handler = cls()
+        handler.store_matches(parameter_handler=parameter_handler, topology=topology)
+        handler.store_potentials(parameter_handler=parameter_handler)
+
+        return handler
+
 
 class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
 
@@ -155,7 +226,9 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
     ] = "k*(1+cos(periodicity*theta-phase))"
 
     def store_matches(
-        self, parameter_handler: ProperTorsionHandler, topology: OFFBioTop
+        self,
+        parameter_handler: "ProperTorsionHandler",
+        topology: "OFFBioTop",
     ) -> None:
         """
         Populate self.slot_map with key-val pairs of slots
@@ -173,7 +246,7 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
                 potential_key = PotentialKey(id=smirks, mult=n)
                 self.slot_map[topology_key] = potential_key
 
-    def store_potentials(self, parameter_handler: ProperTorsionHandler) -> None:
+    def store_potentials(self, parameter_handler: "ProperTorsionHandler") -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
         identifiers and their associated Potential objects
@@ -193,6 +266,19 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
             potential = Potential(parameters=parameters)
             self.potentials[potential_key] = potential
 
+    @classmethod
+    def _from_toolkit(
+        cls: Type[T],
+        parameter_handler: "ProperTorsionHandler",
+        topology: "Topology",
+    ) -> T:
+
+        handler = cls()
+        handler.store_matches(parameter_handler=parameter_handler, topology=topology)
+        handler.store_potentials(parameter_handler=parameter_handler)
+
+        return handler
+
 
 class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
 
@@ -202,7 +288,7 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
     ] = "k*(1+cos(periodicity*theta-phase))"
 
     def store_matches(
-        self, parameter_handler: ImproperTorsionHandler, topology: OFFBioTop
+        self, parameter_handler: "ImproperTorsionHandler", topology: "OFFBioTop"
     ) -> None:
         """
         Populate self.slot_map with key-val pairs of slots
@@ -228,7 +314,7 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
                 potential_key = PotentialKey(id=smirks, mult=n)
                 self.slot_map[topology_key] = potential_key
 
-    def store_potentials(self, parameter_handler: ImproperTorsionHandler) -> None:
+    def store_potentials(self, parameter_handler: "ImproperTorsionHandler") -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
         identifiers and their associated Potential objects
@@ -246,6 +332,21 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
             }
             potential = Potential(parameters=parameters)
             self.potentials[potential_key] = potential
+
+    @classmethod
+    def _from_toolkit(
+        cls: Type[T],
+        improper_torsion_Handler: "ImproperTorsionHandler",
+        topology: "Topology",
+    ) -> T:
+
+        handler = cls()
+        handler.store_matches(
+            parameter_handler=improper_torsion_Handler, topology=topology
+        )
+        handler.store_potentials(parameter_handler=improper_torsion_Handler)
+
+        return handler
 
 
 class SMIRNOFFvdWHandler(SMIRNOFFPotentialHandler):
@@ -327,7 +428,7 @@ class SMIRNOFFElectrostaticsMetadataMixin(DefaultModel):
     def store_charges(
         self,
         forcefield: ForceField,
-        topology: OFFBioTop,
+        topology: "OFFBioTop",
     ) -> None:
         """
         Populate self.slot_map with key-val pairs of slots
@@ -399,7 +500,7 @@ class ElectrostaticsMetaHandler(SMIRNOFFElectrostaticsMetadataMixin):
     charges: Dict = dict()  # type
     cache: Dict = dict()  # Dict[str: Dict[str, FloatQuantity["elementary_charge"]]]
 
-    def cache_charges(self, partial_charge_method: str, topology: OFFBioTop):
+    def cache_charges(self, partial_charge_method: str, topology: "OFFBioTop"):
 
         charges: Dict[TopologyKey, FloatQuantity] = dict()
 

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -122,7 +122,7 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
             constraints.store_constraints(  # type: ignore[union-attr]
                 parameter_handler=constraint_handler,
                 topology=topology,
-                bond_handler=bond_handler,
+                bond_handler=handler,
             )
         else:
             constraints = None

--- a/openff/system/tests/test_matrix_representations.py
+++ b/openff/system/tests/test_matrix_representations.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from openff.utilities.testing import skip_if_missing
 
+from openff.system.components.smirnoff import SMIRNOFFAngleHandler, SMIRNOFFBondHandler
 from openff.system.tests.base_test import BaseTest
 from openff.system.utils import get_test_file_path
 
@@ -18,7 +19,16 @@ class TestMatrixRepresentations(BaseTest):
         import jax
 
         if handler_name == "Bonds":
-            handler, _ = parsley["Bonds"].create_potential(topology=ethanol_top)
+            handler, _ = SMIRNOFFBondHandler.from_toolkit(
+                bond_handler=parsley["Bonds"],
+                topology=ethanol_top,
+                constraint_handler=None,
+            )
+        elif handler_name == "Angles":
+            handler = SMIRNOFFAngleHandler.from_toolkit(
+                parameter_handler=parsley["Angles"],
+                topology=ethanol_top,
+            )
         else:
             handler = parsley[handler_name].create_potential(topology=ethanol_top)
 

--- a/openff/system/tests/test_matrix_representations.py
+++ b/openff/system/tests/test_matrix_representations.py
@@ -2,7 +2,11 @@ import numpy as np
 import pytest
 from openff.utilities.testing import skip_if_missing
 
-from openff.system.components.smirnoff import SMIRNOFFAngleHandler, SMIRNOFFBondHandler
+from openff.system.components.smirnoff import (
+    SMIRNOFFAngleHandler,
+    SMIRNOFFBondHandler,
+    SMIRNOFFvdWHandler,
+)
 from openff.system.tests.base_test import BaseTest
 from openff.system.utils import get_test_file_path
 
@@ -26,11 +30,14 @@ class TestMatrixRepresentations(BaseTest):
             )
         elif handler_name == "Angles":
             handler = SMIRNOFFAngleHandler.from_toolkit(
-                parameter_handler=parsley["Angles"],
+                parameter_handler=parsley[handler_name],
                 topology=ethanol_top,
             )
-        else:
-            handler = parsley[handler_name].create_potential(topology=ethanol_top)
+        elif handler_name == "vdW":
+            handler = SMIRNOFFvdWHandler._from_toolkit(
+                parameter_handler=parsley[handler_name],
+                topology=ethanol_top,
+            )
 
         p = handler.get_force_field_parameters()
 

--- a/openff/system/tests/test_potential.py
+++ b/openff/system/tests/test_potential.py
@@ -6,6 +6,7 @@ from simtk import unit as omm_unit
 
 from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.potentials import PotentialHandler
+from openff.system.components.smirnoff import SMIRNOFFAngleHandler, SMIRNOFFBondHandler
 from openff.system.models import TopologyKey
 from openff.system.tests.base_test import BaseTest
 
@@ -35,7 +36,10 @@ class TestBondPotentialHandler(BaseTest):
 
         forcefield = ForceField()
         forcefield.register_parameter_handler(bond_handler)
-        bond_potentials, _ = forcefield["Bonds"].create_potential(top)
+        bond_potentials, _ = SMIRNOFFBondHandler.from_toolkit(
+            bond_handler=forcefield["Bonds"],
+            topology=top,
+        )
 
         top_key = TopologyKey(atom_indices=(0, 1))
         pot = bond_potentials.potentials[bond_potentials.slot_map[top_key]]
@@ -59,7 +63,10 @@ class TestBondPotentialHandler(BaseTest):
 
         forcefield = ForceField()
         forcefield.register_parameter_handler(angle_handler)
-        angle_potentials = forcefield["Angles"].create_potential(top)
+        angle_potentials = SMIRNOFFAngleHandler.from_toolkit(
+            parameter_handler=forcefield["Angles"],
+            topology=top,
+        )
 
         top_key = TopologyKey(atom_indices=(0, 1, 2))
         pot = angle_potentials.potentials[angle_potentials.slot_map[top_key]]


### PR DESCRIPTION
### Description
This is a follow-on to #173. The idea is that the monkey-patched  `SMIRNOFFPotentialHandler.create_potential` methods should just be `.from_toolkit` class methods. It wasn't until somebody else read this code that it was noticed I monkey-patched within the same package. Oof!


This should make porting to the toolkit simpler.


- [x] Add tests
- [x] Lint
- [ ] Update docstrings
