### PR TITLE
Report all failures in energy tests

### DIFF
--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -6,6 +6,8 @@ dependencies:
     # Base depends
   - python
   - pip
+  - numpy
+  - pandas
   - pydantic
   - pint
   - openmm

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,6 +6,8 @@ dependencies:
     # Base depends
   - python
   - pip
+  - numpy
+  - pandas
   - pydantic
   - pint
   - openmm

--- a/openff/system/tests/energy_tests/test_energies.py
+++ b/openff/system/tests/energy_tests/test_energies.py
@@ -17,6 +17,7 @@ from openff.system.tests.energy_tests.openmm import (
     _get_openmm_energies,
     get_openmm_energies,
 )
+from openff.system.tests.energy_tests.report import EnergyError, EnergyReport
 
 HAS_GROMACS = any(has_executable(e) for e in ["gmx", "gmx_d"])
 HAS_LAMMPS = any(has_executable(e) for e in ["lammps", "lmp_mpi", "lmp_serial"])
@@ -32,6 +33,32 @@ if HAS_LAMMPS:
 
 needs_gmx = pytest.mark.skipif(not HAS_GROMACS, reason="Needs GROMACS")
 needs_lmp = pytest.mark.skipif(not HAS_LAMMPS, reason="Needs GROMACS")
+
+
+def test_energy_report():
+    """Test that multiple failing energies are captured in the EnergyError"""
+    kj_mol = unit.kilojoule / unit.mol
+    a = EnergyReport(
+        energies={
+            "a": 1 * kj_mol,
+            "_FLAG": 2 * kj_mol,
+            "KEY_": 1.2 * kj_mol,
+        }
+    )
+    b = EnergyReport(
+        energies={
+            "a": -1 * kj_mol,
+            "_FLAG": -2 * kj_mol,
+            "KEY_": -0.1 * kj_mol,
+        }
+    )
+    custom_tolerances = {
+        "a": 1 * kj_mol,
+        "_FLAG": 1 * kj_mol,
+        "KEY_": 1 * kj_mol,
+    }
+    with pytest.raises(EnergyError, match=r"_FLAG[\s\S]*KEY_"):
+        a.compare(b, custom_tolerances=custom_tolerances)
 
 
 @skip_if_missing("mbuild")

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=numpy,sympy,openff.toolkit,openff.units,pint,pytest,simtk,mdtraj,pydantic,parmed,pmdtest
+known_third_party=numpy,pandas,openff.toolkit,openff.units,pint,pytest,simtk,mdtraj,pydantic,parmed,pmdtest
 
 [versioneer]
 # Automatic version numbering scheme
@@ -54,7 +54,7 @@ ignore_missing_imports = True
 [mypy-scipy.constants]
 ignore_missing_imports = True
 
-[mypy-sympy]
+[mypy-pandas]
 ignore_missing_imports = True
 
 [mypy-numpy.*]


### PR DESCRIPTION
### Description
Previously, a failing energy test (`energy_report.compare(other_energy_report)`) would only report the first kind of energy that failed a comparison, which led to some headaches in debugging. For example, if all valence energies were off, only one was reported (probably bonds, but not always ordered) and the others were not reported. The output is also significantly more human-readable.

I'm lazy and using a pandas data frame for this, which could be removed in the future if we don't need it for any other uses.

Before:
```
Traceback (most recent call last):
  File "/Users/mwt/software/openff-system/energy_report.py", line 24, in <module>
    a.compare(
  File "/Users/mwt/software/openff-system/openff/system/tests/energy_tests/report.py", line 111, in compare
    raise EnergyError(
openff.system.tests.energy_tests.report.EnergyError: ('a', <Quantity(2, 'kilojoule / mole')>, <Quantity(1, 'kilojoule / mole')>, <Quantity(1, 'kilojoule / mole')>, <Quantity(-1, 'kilojoule / mole')>)
```


After:
```
Traceback (most recent call last):
  File "/Users/mwt/software/openff-system/energy_report.py", line 24, in <module>
    a.compare(
  File "/Users/mwt/software/openff-system/openff/system/tests/energy_tests/report.py", line 151, in compare
    raise EnergyError(
openff.system.tests.energy_tests.report.EnergyError:
Some energy difference(s) exceed tolerances!
All values are reported in kJ/mol:
key      diff  tol     ener1     ener2
  a  2.000000    1  1.000000 -1.000000
  b  4.000000    1  2.000000 -2.000000
  x  1.300000    1  1.200000 -0.100000
  y  1.500000    1  1.300000 -0.200000
  z 17.904762    1 17.571429 -0.333333
```

Script:
```python3
from openff.units import unit

from openff.system.tests.energy_tests.report import EnergyReport

kj_mol = unit.kilojoule / unit.mol
a = EnergyReport(
    energies={
        "a": 1 * kj_mol,
        "b": 2 * kj_mol,
        "x": 1.2 * kj_mol,
        "y": 1.3 * kj_mol,
        "z": 123/7 * kj_mol,
    }
)
b = EnergyReport(
    energies={
        "a": -1 * kj_mol,
        "b": -2 * kj_mol,
        "x": -0.1 * kj_mol,
        "y": -0.2 * kj_mol,
        "z": -(1/3) * kj_mol,
    }
)
a.compare(
    b,
    custom_tolerances={
        "a": 1 * kj_mol,
        "b": 1 * kj_mol,
        "x": 1 * kj_mol,
        "y": 1 * kj_mol,
        "z": 1 * kj_mol,
    },
)
```

### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
