### PR TITLE
Use panedr to parse GROMACS energy files

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -29,3 +29,4 @@ dependencies:
   - lammps
   - mbuild
   - foyer>=0.8.0
+  - panedr

--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -178,12 +178,6 @@ class GMXMdrunError(GMXRunError):
     """
 
 
-class GMXEnergyError(GMXRunError):
-    """
-    Exception for when `gmx energy` fails.
-    """
-
-
 class LAMMPSRunError(BaseException):
     """
     Exception for when a LAMMPS subprocess fails.


### PR DESCRIPTION
### Description
Yesterday, we ran into some peculiar behavior with the code that parses energy files. This PR drops the call to `gmx energy`, which turns the binary `.edr` files into human-readable `.xvg` files, and uses `panedr` to directly parse the binaries. This picks up a free win by skipping the shell call that handles the conversion.

A better solution may involve keeping both code paths active, but using `panedr` output as a reference. I trust it more than my ability  (and patience) to write perfect file parsers.

Thanks to @justinGilmer for the suggestion.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
