### PR TITLE
Fix from SMIRNOFF used with base OFF topology

### DIFF
--- a/openff/system/components/mdtraj.py
+++ b/openff/system/components/mdtraj.py
@@ -1,3 +1,5 @@
+import copy
+
 import mdtraj as md
 from openff.toolkit.topology import Topology
 
@@ -6,6 +8,18 @@ class OFFBioTop(Topology):
     def __init__(self, mdtop=None, *args, **kwargs):
         self.mdtop = mdtop
         super().__init__(*args, **kwargs)
+
+    def copy_initializer(self, other: Topology):
+        # TODO: The OFFBioTop cannot use the `other` kwarg until TK 946 is resolved.
+        self._aromaticity_model = other.aromaticity_model
+        self._constrained_atom_pairs = copy.deepcopy(other.constrained_atom_pairs)
+        self._box_vectors = copy.deepcopy(other.box_vectors)
+        # self._reference_molecule_dicts = set()
+        # TODO: Look into weakref and what it does. Having multiple topologies might cause a memory leak.
+        self._reference_molecule_to_topology_molecules = copy.deepcopy(
+            other._reference_molecule_to_topology_molecules
+        )
+        self._topology_molecules = copy.deepcopy(other.topology_molecules)
 
 
 def _store_bond_partners(mdtop):

--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -168,7 +168,7 @@ class System(DefaultModel):
         if isinstance(topology, OFFBioTop):
             sys_out.topology = topology
         elif isinstance(topology, Topology):
-            sys_out.topology = OFFBioTop(topology)
+            sys_out.topology = OFFBioTop(other=topology)
             sys_out.topology.mdtop = md.Topology.from_openmm(topology.to_openmm())
         else:
             raise InvalidTopologyError(

--- a/openff/system/tests/test_system.py
+++ b/openff/system/tests/test_system.py
@@ -42,8 +42,9 @@ def test_getitem():
 class TestFromSMIRNOFF(BaseTest):
     """Test the functionality of the stubs.py module"""
 
-    def test_from_parsley(self, parsley):
-        top = OFFBioTop.from_molecules(
+    @pytest.mark.parametrize("topology_type", [OFFBioTop, Topology])
+    def test_from_parsley(self, topology_type, parsley):
+        top = topology_type.from_molecules(
             [Molecule.from_smiles("CCO"), Molecule.from_smiles("CC")]
         )
 
@@ -58,6 +59,8 @@ class TestFromSMIRNOFF(BaseTest):
         assert type(out.topology) == OFFBioTop
         assert type(out.topology) != Topology
         assert isinstance(out.topology, Topology)
+
+        assert len(out.topology.topology_molecules) == 2
 
     def test_unsupported_handler(self):
         gbsa_ff = ForceField(get_data_file_path("test_forcefields/GBSA_HCT-1.0.offxml"))


### PR DESCRIPTION
### Description

This PR fixes creating an OpenFF system object using the `from_smirnoff` class method with a base OpenFF `Topology` object and not an `OFFBioTop`. Previously the existing topology was passed as the `mdtraj` arg, rather than the `other` kwarg.

The PR further adds a workaround to https://github.com/openforcefield/openff-toolkit/issues/946 as OpenFF topologies cannot currently be instantiated from `other`.

### Checklist
- [X] Add tests
- [X] Lint
- [X] Update docstrings
