### PR TITLE
Add cron job, turn off macOS jobs in CI

### DIFF
--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,14 +1,8 @@
-name: full_tests
+name: nightly tests
 
 on:
-  push:
-    branches:
-      - "master"
-      - "maintenance/.+"
-  pull_request:
-    branches:
-      - "master"
-      - "maintenance/.+"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   test:
@@ -16,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}


### PR DESCRIPTION
### Description
macOS jobs are slow and shared across the organization (limit 5 concurrently across all projects). Given that the differences tend to be small for pure Python packages and that I develop on macOS, and Linux builds are quicker and normally have no queue, it doesn't make much sense to stall progress by waiting on macOS jobs to finish. This also adds nightly tests, which do include macOS builds.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
