### PR TITLE
Split NonbondedForce in to_openmm

### DIFF
--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -37,7 +37,6 @@ from openff.system.exceptions import (
     MissingPositionsError,
     UnsupportedExportError,
 )
-from openff.system.interop.openmm import to_openmm
 from openff.system.models import DefaultModel
 from openff.system.types import ArrayQuantity
 
@@ -330,9 +329,11 @@ class System(DefaultModel):
 
         to_lammps(self, file_path)
 
-    def to_openmm(self):
+    def to_openmm(self, combine_nonbonded_forces: bool = False):
         """Export this system to an OpenMM System"""
-        return to_openmm(self)
+        from openff.system.interop.openmm import to_openmm as to_openmm_
+
+        return to_openmm_(self, combine_nonbonded_forces=combine_nonbonded_forces)
 
     def to_prmtop(self, file_path: Union[Path, str], writer="parmed"):
         """Export this system to an Amber .prmtop file"""

--- a/openff/system/drivers/openmm.py
+++ b/openff/system/drivers/openmm.py
@@ -178,8 +178,8 @@ def _get_openmm_energies(
 
     report.update_energies(
         {
-            "Bond": omm_energies.get("HarmonicBondForce", 0.0),
-            "Angle": omm_energies.get("HarmonicAngleForce", 0.0),
+            "Bond": omm_energies.get("HarmonicBondForce", 0.0 * kj_mol),
+            "Angle": omm_energies.get("HarmonicAngleForce", 0.0 * kj_mol),
             "Torsion": _canonicalize_torsion_energies(omm_energies),
             "Nonbonded": omm_energies.get(
                 "Nonbonded", _canonicalize_nonbonded_energies(omm_energies)

--- a/openff/system/drivers/openmm.py
+++ b/openff/system/drivers/openmm.py
@@ -99,12 +99,14 @@ def _get_openmm_energies(
     electrostatics: bool = True,
 ) -> EnergyReport:
     """Given a prepared `openmm.System`, run a single-point energy calculation."""
+    """\
     if hard_cutoff:
         omm_sys = _set_nonbonded_method(
             omm_sys, "cutoff", electrostatics=electrostatics
         )
     else:
         omm_sys = _set_nonbonded_method(omm_sys, "PME")
+    """
 
     force_names = {force.__class__.__name__ for force in omm_sys.getForces()}
     group_to_force = {i: force_name for i, force_name in enumerate(force_names)}

--- a/openff/system/drivers/openmm.py
+++ b/openff/system/drivers/openmm.py
@@ -14,6 +14,7 @@ def get_openmm_energies(
     round_positions=None,
     hard_cutoff: bool = False,
     electrostatics: bool = True,
+    combine_nonbonded_forces: bool = False,
 ) -> EnergyReport:
     """
     Given an OpenFF System object, return single-point energies as computed by OpenMM.
@@ -45,7 +46,9 @@ def get_openmm_energies(
 
     """
 
-    omm_sys: openmm.System = off_sys.to_openmm()
+    omm_sys: openmm.System = off_sys.to_openmm(
+        combine_nonbonded_forces=combine_nonbonded_forces
+    )
 
     return _get_openmm_energies(
         omm_sys=omm_sys,
@@ -108,19 +111,14 @@ def _get_openmm_energies(
         omm_sys = _set_nonbonded_method(omm_sys, "PME")
     """
 
-    force_names = {force.__class__.__name__ for force in omm_sys.getForces()}
-    group_to_force = {i: force_name for i, force_name in enumerate(force_names)}
-    force_to_group = {force_name: i for i, force_name in group_to_force.items()}
-
-    for force in omm_sys.getForces():
-        force_name = force.__class__.__name__
-        force.setForceGroup(force_to_group[force_name])
+    for idx, force in enumerate(omm_sys.getForces()):
+        force.setForceGroup(idx)
 
     integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
     context = openmm.Context(omm_sys, integrator)
 
     if box_vectors is not None:
-        if not isinstance(box_vectors, unit.Quantity):
+        if not isinstance(box_vectors, (unit.Quantity, list)):
             box_vectors = box_vectors.magnitude * unit.nanometer
         context.setPeriodicBoxVectors(*box_vectors)
 
@@ -136,14 +134,32 @@ def _get_openmm_energies(
     else:
         context.setPositions(positions)
 
-    force_groups = {force.getForceGroup() for force in context.getSystem().getForces()}
-
+    raw_energies = dict()
     omm_energies = dict()
 
-    for force_group in force_groups:
-        state = context.getState(getEnergy=True, groups={force_group})
-        omm_energies[group_to_force[force_group]] = state.getPotentialEnergy()
+    for idx in range(omm_sys.getNumForces()):
+        state = context.getState(getEnergy=True, groups={idx})
+        raw_energies[idx] = state.getPotentialEnergy()
         del state
+
+    # This assumes that only custom forces will have duplicate instances
+    for key in raw_energies:
+        force = omm_sys.getForce(key)
+        if type(force) == openmm.HarmonicBondForce:
+            omm_energies["HarmonicBondForce"] = raw_energies[key]
+        elif type(force) == openmm.HarmonicAngleForce:
+            omm_energies["HarmonicAngleForce"] = raw_energies[key]
+        elif type(force) == openmm.PeriodicTorsionForce:
+            omm_energies["PeriodicTorsionForce"] = raw_energies[key]
+        elif type(force) in [
+            openmm.NonbondedForce,
+            openmm.CustomNonbondedForce,
+            openmm.CustomBondForce,
+        ]:
+            if "Nonbonded" in omm_energies:
+                omm_energies["Nonbonded"] += raw_energies[key]
+            else:
+                omm_energies["Nonbonded"] = raw_energies[key]
 
     # Fill in missing keys if system does not have all typical forces
     for required_key in [
@@ -152,8 +168,8 @@ def _get_openmm_energies(
         "PeriodicTorsionForce",
         "NonbondedForce",
     ]:
-        if required_key not in omm_energies:
-            omm_energies[required_key] = 0.0 * kj_mol
+        if not any(required_key in val for val in omm_energies):
+            pass  # omm_energies[required_key] = 0.0 * kj_mol
 
     del context
     del integrator
@@ -162,10 +178,12 @@ def _get_openmm_energies(
 
     report.update_energies(
         {
-            "Bond": omm_energies["HarmonicBondForce"],
-            "Angle": omm_energies["HarmonicAngleForce"],
+            "Bond": omm_energies.get("HarmonicBondForce", 0.0),
+            "Angle": omm_energies.get("HarmonicAngleForce", 0.0),
             "Torsion": _canonicalize_torsion_energies(omm_energies),
-            "Nonbonded": _canonicalize_nonbonded_energies(omm_energies),
+            "Nonbonded": omm_energies.get(
+                "Nonbonded", _canonicalize_nonbonded_energies(omm_energies)
+            ),
         }
     )
 
@@ -177,7 +195,7 @@ def _get_openmm_energies(
 
 def _canonicalize_nonbonded_energies(energies: Dict):
     omm_nonbonded = 0.0 * kj_mol
-    for key in ["NonbondedForce", "CustomNonbondedForce"]:
+    for key in ["NonbondedForce", "CustomNonbondedForce", "CustomBondForce"]:
         try:
             omm_nonbonded += energies[key]
         except KeyError:

--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -414,7 +414,7 @@ def _process_nonbonded_forces(openff_sys, openmm_sys):
     """
 
     combined_14_force = openmm.CustomBondForce(
-        f"4*epsilon*((sigma/r)^12-(sigma/r)^6)-{coul_const}*qq/r"
+        f"4*epsilon*((sigma/r)^12-(sigma/r)^6)+{coul_const}*qq/r"
     )
     combined_14_force.addPerBondParameter("sigma")
     combined_14_force.addPerBondParameter("epsilon")

--- a/openff/system/tests/interop/test_external.py
+++ b/openff/system/tests/interop/test_external.py
@@ -89,7 +89,11 @@ class TestFromOpenMM(BaseTest):
             pdbfile.getPositions().value_in_unit(nm),
         )
 
-        get_openmm_energies(out, hard_cutoff=True).compare(
+        get_openmm_energies(
+            out,
+            hard_cutoff=True,
+            combine_nonbonded_forces=True,
+        ).compare(
             _get_openmm_energies(
                 omm_sys=ff.create_openmm_system(top),
                 box_vectors=pdbfile.topology.getPeriodicBoxVectors(),

--- a/openff/system/tests/interop/test_openmm.py
+++ b/openff/system/tests/interop/test_openmm.py
@@ -2,7 +2,7 @@ import mdtraj as md
 import numpy as np
 import pytest
 from openff.toolkit.tests.test_forcefield import create_ethanol
-from openff.toolkit.tests.utils import compare_system_energies, get_data_file_path
+from openff.toolkit.tests.utils import get_data_file_path
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import SMIRNOFFSpecError
 from simtk import openmm
@@ -11,7 +11,7 @@ from simtk.openmm import app
 
 from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.system import System
-from openff.system.drivers import get_openmm_energies
+from openff.system.drivers.openmm import _get_openmm_energies, get_openmm_energies
 from openff.system.exceptions import (
     UnsupportedCutoffMethodError,
     UnsupportedExportError,
@@ -37,7 +37,7 @@ nonbonded_resolution_matrix = [
         "vdw_method": "PME",
         "electrostatics_method": "PME",
         "periodic": True,
-        "result": UnsupportedCutoffMethodError,
+        "result": openmm.NonbondedForce.LJPME,
     },
     {
         "vdw_method": "PME",
@@ -144,7 +144,7 @@ def test_openmm_nonbonded_methods(inputs):
             "Electrostatics", {}
         ).method = electrostatics_method
         openff_system = System.from_smirnoff(force_field=forcefield, topology=topology)
-        openmm_system = openff_system.to_openmm()
+        openmm_system = openff_system.to_openmm(combine_nonbonded_forces=True)
         for force in openmm_system.getForces():
             if isinstance(force, openmm.NonbondedForce):
                 assert force.getNonbondedMethod() == nonbonded_method
@@ -161,7 +161,7 @@ def test_openmm_nonbonded_methods(inputs):
             openff_system = System.from_smirnoff(
                 force_field=forcefield, topology=topology
             )
-            openff_system.to_openmm()
+            openff_system.to_openmm(combine_nonbonded_forces=True)
     else:
         raise Exception("uh oh")
 
@@ -177,8 +177,8 @@ def test_unsupported_mixing_rule():
 
     openff_sys["vdW"].mixing_rule = "geometric"
 
-    with pytest.raises(UnsupportedExportError, match="rule `geometric` not compat"):
-        openff_sys.to_openmm()
+    with pytest.raises(UnsupportedExportError, match="default NonbondedForce"):
+        openff_sys.to_openmm(combine_nonbonded_forces=True)
 
 
 @pytest.mark.slow
@@ -223,13 +223,18 @@ def test_from_openmm_single_mols(mol, n_mols):
 
     native_system = System.from_smirnoff(force_field=parsley, topology=top).to_openmm()
 
-    compare_system_energies(
-        system1=toolkit_system,
-        system2=native_system,
+    toolkit_energy = _get_openmm_energies(
+        omm_sys=toolkit_system,
+        box_vectors=toolkit_system.getDefaultPeriodicBoxVectors(),
         positions=positions,
-        box_vectors=top.box_vectors,
-        atol=1e-5,
     )
+    native_energy = _get_openmm_energies(
+        omm_sys=native_system,
+        box_vectors=native_system.getDefaultPeriodicBoxVectors(),
+        positions=positions,
+    )
+
+    toolkit_energy.compare(native_energy)
 
 
 @pytest.mark.slow
@@ -260,4 +265,27 @@ def test_openmm_roundtrip():
     get_openmm_energies(off_sys).compare(
         get_openmm_energies(converted),
         custom_tolerances={"Nonbonded": 1.5 * simtk_unit.kilojoule_per_mole},
+    )
+
+
+def test_combine_nonbonded_forces():
+
+    mol = Molecule.from_smiles("ClC#CCl")
+    mol.name = "HPER"
+    mol.generate_conformers(n_conformers=1)
+
+    parsley = ForceField("openff_unconstrained-1.0.0.offxml")
+
+    out = System.from_smirnoff(force_field=parsley, topology=mol.to_topology())
+    out.box = [4, 4, 4]
+    out.positions = mol.conformers[0]
+
+    num_forces_combined = out.to_openmm(combine_nonbonded_forces=True).getNumForces()
+    num_forces_uncombined = out.to_openmm(combine_nonbonded_forces=False).getNumForces()
+
+    # The "new" forces are the split-off vdW forces, the 1-4 vdW, and the 1-4 electrostatics
+    assert num_forces_combined + 3 == num_forces_uncombined
+
+    get_openmm_energies(out, combine_nonbonded_forces=False).compare(
+        get_openmm_energies(out, combine_nonbonded_forces=True),
     )


### PR DESCRIPTION
### Description
This takes https://github.com/openforcefield/openff-toolkit/pull/920 and tries to implement it here.

This is the script I'm currently using to set a trace:

```python3
from openff.toolkit.topology import Molecule

from openff.system.stubs import ForceField

mol = Molecule.from_smiles("ClC#CCl")
mol.name = "HPER"
mol.generate_conformers(n_conformers=1)

parsley = ForceField("openff_unconstrained-1.0.0.offxml")

out = parsley.create_openff_system(topology=mol.to_topology())
out.box = [4, 4, 4]
out.positions = mol.conformers[0]

out['Electrostatics'].method='pme'
out.to_gro("out.gro", writer="internal")
out.to_top("out.top", writer="internal")

from openff.system.drivers.gromacs import _run_gmx_energy, _write_mdp_file
from openff.system.drivers.openmm import get_openmm_energies
_write_mdp_file(openff_sys=out)
print(_run_gmx_energy(top_file='out.top', gro_file='out.gro', mdp_file='auto_generated.mdp'))
print(get_openmm_energies(out))
```

Pretty close to working now, but not quite there (at least while using GROMACS as a reference):
```
# GROMACS
Energies:

Bond:          		1.0871152877807617 kJ / mol
Angle:         		0.17977555096149445 kJ / mol
Torsion:       		0.0 kJ / mol
Nonbonded:     		None
vdW:           		-0.30658775568008423 kJ / mol
Electrostatics:		2.093082904815674 kJ / mol

# OpenMM
Energies:

Bond:          		1.0871620178222656 kJ / mol
Angle:         		0.17984433472156525 kJ / mol
Torsion:       		0.0 kJ / mol
Nonbonded:     		0.00011830426331371768 kJ / mol
vdW:           		None
Electrostatics:		None
```
and this report is missing -2.4035933017730713 kJ/mol in 1-4 interactions (including both vdW and electrostatics).

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
