### PR TITLE
MAINT: Update environments/docs for openff-units conda package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,11 +60,6 @@ jobs:
       run: |
         python setup.py develop --no-deps
 
-    - name: Install OpenFF Units
-      shell: bash -l {0}
-      run: |
-        pip install git+git://github.com/mattwthompson/openff-units.git
-
     - name: Clone ParmEd tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -53,11 +53,6 @@ jobs:
       run: |
         python setup.py develop --no-deps
 
-    - name: Install OpenFF Units
-      shell: bash -l {0}
-      run: |
-        pip install git+git://github.com/mattwthompson/openff-units.git
-
     - name: Run unit tests
       if: always()
       shell: bash -l {0}

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -12,6 +12,7 @@ dependencies:
   - openmm
   - openff-toolkit
   - openff-utilities
+  - openff-units
   - jax
   - mdtraj
   - ele

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,6 +13,7 @@ dependencies:
   - openmm
   - openff-toolkit
   - openff-utilities
+  - openff-units
   - jax
   - mdtraj
   - ele

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,23 +9,17 @@ Until a conda package is live, the core dependencies are listed in `devtools/con
 Required dependencies:
   - python
   - pip
+  - numpy
+  - pandas
   - pydantic
   - pint
   - openmm
   - openff-toolkit
+  - openff-units
+  - openff-utilities
   - jax
   - mdtraj
   - ele
-  - `openff-units`
-  - `openff-utilities`
-
-Note that the last two packages are currently unrelreased and must be installed as development builds:
-
-```shell
-# In an activated conda environment
-pip install git+git://github.com/mattwthompson/openff-units.git
-pip install git+git://github.com/mattwthompson/openff-utilities.git
-```
 
 Optional/test/dev dependencies:
   - pytest
@@ -36,9 +30,10 @@ Optional/test/dev dependencies:
   - unyt
   - intermol
   - gromacs >=2021
+  - panedr
   - lammps
   - mbuild
-  - foyer>=0.8.0
+  - foyer >=0.8.0
 
 If portions of the API that require optional dependencies are called while some of those dependencies are not available, an informative error message should be provided.
 


### PR DESCRIPTION
### Description
OpenFF Units is now on `conda-forge`, so I can remove the  hacks I put in. And also update the installation docs.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
