### PR TITLE
Let potential handlers specify allowed parameter handlers

### DIFF
--- a/openff/system/components/system.py
+++ b/openff/system/components/system.py
@@ -189,7 +189,7 @@ class System(DefaultModel):
                     constraint_handler = force_field["Constraints"]
                 else:
                     constraint_handler = None
-                potential_handler, constraints = SMIRNOFFBondHandler.from_toolkit(
+                potential_handler, constraints = SMIRNOFFBondHandler._from_toolkit(
                     bond_handler=force_field["Bonds"],
                     topology=topology,
                     constraint_handler=constraint_handler,
@@ -206,7 +206,7 @@ class System(DefaultModel):
                 POTENTIAL_HANDLER_CLASS = _SMIRNOFF_HANDLER_MAPPINGS[
                     parameter_handler.__class__
                 ]
-                potential_handler = POTENTIAL_HANDLER_CLASS.from_toolkit(  # type: ignore[assignment]
+                potential_handler = POTENTIAL_HANDLER_CLASS._from_toolkit(  # type: ignore[assignment]
                     parameter_handler=parameter_handler,
                     topology=topology,
                 )

--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -34,6 +34,12 @@ class ToolkitTopologyConformersNotFoundError(Exception):
             msg += f"The molecule lacking a conformer is {self.mol}"
 
 
+class InvalidParameterHandlerError(ValueError):
+    """
+    Generic exception for mismatch between expected and found ParameterHandler types
+    """
+
+
 class InvalidBoxError(ValueError):
     """
     Generic exception for errors reading box data

--- a/openff/system/tests/components/test_smirnoff.py
+++ b/openff/system/tests/components/test_smirnoff.py
@@ -1,6 +1,8 @@
+from typing import Any, List
+
 import numpy as np
 import pytest
-from openff.toolkit.topology import Molecule
+from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ImproperTorsionHandler
 from openff.toolkit.typing.engines.smirnoff.parameters import AngleHandler, BondHandler
 from openff.units import unit
@@ -13,11 +15,28 @@ from openff.system.components.smirnoff import (
     SMIRNOFFAngleHandler,
     SMIRNOFFBondHandler,
     SMIRNOFFImproperTorsionHandler,
+    SMIRNOFFPotentialHandler,
     SMIRNOFFvdWHandler,
 )
+from openff.system.exceptions import InvalidParameterHandlerError
 from openff.system.models import TopologyKey
 from openff.system.tests import BaseTest
 from openff.system.utils import get_test_file_path
+
+
+class TestSMIRNOFFPotentialHandler(BaseTest):
+    def test_allowed_parameter_handler_types(self):
+        class DummySMIRNOFFHandler(SMIRNOFFPotentialHandler):
+            type = "Bonds"
+            expression = "1+1"
+            _ALLOWED_PARAMETER_HANDLERS: List[Any] = [BondHandler]
+
+        angle_handler = AngleHandler(version=0.3)
+
+        with pytest.raises(InvalidParameterHandlerError):
+            DummySMIRNOFFHandler.from_toolkit(
+                parameter_handler=angle_handler, topology=Topology()
+            )
 
 
 class TestSMIRNOFFHandlers(BaseTest):


### PR DESCRIPTION
### Description
This PR is a prerequisite for finishing #200.

I bet there's a more elegant way to to this - I had a difficult time figuring out how to use Pydantic features to validate something that's not stored in the model.

### Checklist
- [ ] Enforce this check in `ParameterHandler.store_mathces` and `ParameterHandler.store_potentials`? Maybe with a decorator?
- [ ] Let `ParameterHandler.from_smirnoff` accept a list of parameter handlers
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
