### PR TITLE
Add PotentialKey.associated_handler

### DIFF
--- a/examples/SMIRNOFF_simulation.ipynb
+++ b/examples/SMIRNOFF_simulation.ipynb
@@ -58,7 +58,7 @@
    "outputs": [],
    "source": [
     "# Convert the OpenFF System to an OpenMM System\n",
-    "openmm_sys = openff_sys.to_openmm()"
+    "openmm_sys = openff_sys.to_openmm(combine_nonbonded_forces=True)"
    ]
   },
   {

--- a/examples/smirnoff_argon.ipynb
+++ b/examples/smirnoff_argon.ipynb
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "# Look at this contents of this Potential object\n",
-    "potential_key = PotentialKey(id=\"[#18:1]\")\n",
+    "potential_key = PotentialKey(id=\"[#18:1]\", associated_handler=\"vdW\")\n",
     "vdw.potentials[potential_key]"
    ]
   },

--- a/examples/smirnoff_ethanol.ipynb
+++ b/examples/smirnoff_ethanol.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "# Look at this contents of one of the Potential objects\n",
-    "potential_key = PotentialKey(id=\"[#6X4:1]-[#1:2]\")\n",
+    "potential_key = PotentialKey(id=\"[#6X4:1]-[#1:2]\", associated_handler=\"Bonds\")\n",
     "bonds.potentials[potential_key]"
    ]
   },

--- a/openff/system/components/smirnoff.py
+++ b/openff/system/components/smirnoff.py
@@ -54,6 +54,7 @@ class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
         and unique potential identifiers
 
         """
+        parameter_handler_name = getattr(parameter_handler, "_TAGNAME", None)
         if self.slot_map:
             # TODO: Should the slot_map always be reset, or should we be able to partially
             # update it? Also Note the duplicated code in the child classes
@@ -61,7 +62,9 @@ class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
         matches = parameter_handler.find_matches(topology)
         for key, val in matches.items():
             topology_key = TopologyKey(atom_indices=key)
-            potential_key = PotentialKey(id=val.parameter_type.smirks)
+            potential_key = PotentialKey(
+                id=val.parameter_type.smirks, associated_handler=parameter_handler_name
+            )
             self.slot_map[topology_key] = potential_key
 
     @classmethod
@@ -176,7 +179,9 @@ class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
             distance = match.parameter_type.distance
             if distance is not None:
                 # This constraint parameter is fully specified
-                potential_key = PotentialKey(id=smirks)
+                potential_key = PotentialKey(
+                    id=smirks, associated_handler="Constraints"
+                )
                 distance = match.parameter_type.distance
             else:
                 # This constraint parameter depends on the BondHandler
@@ -274,7 +279,9 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
             for n in range(n_terms):
                 smirks = val.parameter_type.smirks
                 topology_key = TopologyKey(atom_indices=key, mult=n)
-                potential_key = PotentialKey(id=smirks, mult=n)
+                potential_key = PotentialKey(
+                    id=smirks, mult=n, associated_handler="ProperTorsions"
+                )
                 self.slot_map[topology_key] = potential_key
 
     def store_potentials(self, parameter_handler: "ProperTorsionHandler") -> None:
@@ -347,7 +354,9 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
                     topology_key = TopologyKey(
                         atom_indices=(key[1], *permuted_key), mult=n
                     )
-                    potential_key = PotentialKey(id=smirks, mult=n)
+                    potential_key = PotentialKey(
+                        id=smirks, mult=n, associated_handler="ImproperTorsions"
+                    )
                     self.slot_map[topology_key] = potential_key
 
     def store_potentials(self, parameter_handler: "ImproperTorsionHandler") -> None:

--- a/openff/system/models.py
+++ b/openff/system/models.py
@@ -36,6 +36,11 @@ class PotentialKey(DefaultModel):
     mult: Optional[int] = Field(
         None, description="The index of this duplicate interaction"
     )
+    associated_handler: Optional[str] = Field(
+        None,
+        description="The type of handler this potential key is associated with, "
+        "i.e. 'Bonds', 'vdW', or 'LibraryCharges",
+    )
 
     def __hash__(self):
         return hash((self.id, self.mult))

--- a/openff/system/tests/components/test_smirnoff.py
+++ b/openff/system/tests/components/test_smirnoff.py
@@ -87,7 +87,9 @@ class TestSMIRNOFFHandlers(BaseTest):
         )
 
         top_key = TopologyKey(atom_indices=(0, 1))
-        pot = bond_potentials.potentials[bond_potentials.slot_map[top_key]]
+        pot_key = bond_potentials.slot_map[top_key]
+        assert pot_key.associated_handler == "Bonds"
+        pot = bond_potentials.potentials[pot_key]
 
         kcal_mol_a2 = unit.Unit("kilocalorie / (angstrom ** 2 * mole)")
         assert pot.parameters["k"].to(kcal_mol_a2).magnitude == pytest.approx(1.5)
@@ -114,7 +116,9 @@ class TestSMIRNOFFHandlers(BaseTest):
         )
 
         top_key = TopologyKey(atom_indices=(0, 1, 2))
-        pot = angle_potentials.potentials[angle_potentials.slot_map[top_key]]
+        pot_key = angle_potentials.slot_map[top_key]
+        assert pot_key.associated_handler == "Angles"
+        pot = angle_potentials.potentials[pot_key]
 
         kcal_mol_rad2 = unit.Unit("kilocalorie / (mole * radian ** 2)")
         assert pot.parameters["k"].to(kcal_mol_rad2).magnitude == pytest.approx(2.5)


### PR DESCRIPTION
### Description
This PR adds an optional field to `PotentialKey` for storing the handler that a key is associated with. This seems somewhat trivial for valence parameters, i.e. a potential key between two atoms _stored in_ a `SMIRNOFFBondHandler` is obviously associated with a `BondHandler` parameter handler. It's less obvious, however, for electrostatics models (and likely some more complicated virtual site treatments) in which multiple handlers can apply to the same "slot," i.e. multiple electrostatics parameter handlers can apply to the same atom. This is needed for/a part of #200. This also sets the stage for more complex relationships between parameters and potentials.

I'm currently storing the new field as a string, this may need to change in the future.


### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
