### PR TITLE
Fix constraints

### DIFF
--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -295,8 +295,9 @@ def _process_nonbonded_forces(openff_sys, openmm_sys, combine_nonbonded_forces=F
                     raise UnsupportedCutoffMethodError
             else:
                 raise UnimplementedCutoffMethodError(
-                    f"Combination of non-bonded cutoff methods {vdw_cutoff=} and "
-                    f"{electrostatics_method=} not currently supported with {combine_nonbonded_forces=}"
+                    f"Combination of non-bonded cutoff methods {vdw_cutoff} (vdW) and "
+                    f"{electrostatics_method} (Electrostatics) not currently supported with "
+                    f"`combine_nonbonded_forces={combine_nonbonded_forces}"
                 )
 
         else:

--- a/openff/system/interop/openmm.py
+++ b/openff/system/interop/openmm.py
@@ -294,7 +294,10 @@ def _process_nonbonded_forces(openff_sys, openmm_sys, combine_nonbonded_forces=F
                 else:
                     raise UnsupportedCutoffMethodError
             else:
-                raise NotImplementedError
+                raise UnimplementedCutoffMethodError(
+                    f"Combination of non-bonded cutoff methods {vdw_cutoff=} and "
+                    f"{electrostatics_method=} not currently supported with {combine_nonbonded_forces=}"
+                )
 
         else:
             vdw_expression = vdw_handler.expression

--- a/openff/system/interop/parmed.py
+++ b/openff/system/interop/parmed.py
@@ -214,7 +214,8 @@ def _to_parmed(off_system: "System") -> "pmd.Structure":
         pmd_atom.type = atom_type.name
         pmd_atom.name = pmd_atom.type
 
-    charges = electrostatics_handler.charges
+    if has_electrostatics:
+        charges = electrostatics_handler.charges
 
     for pmd_idx, pmd_atom in enumerate(structure.atoms):
         if has_electrostatics:

--- a/openff/system/tests/components/test_smirnoff.py
+++ b/openff/system/tests/components/test_smirnoff.py
@@ -21,6 +21,7 @@ from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.smirnoff import (
     SMIRNOFFAngleHandler,
     SMIRNOFFBondHandler,
+    SMIRNOFFConstraintHandler,
     SMIRNOFFElectrostaticsHandler,
     SMIRNOFFImproperTorsionHandler,
     SMIRNOFFPotentialHandler,
@@ -88,8 +89,8 @@ class TestSMIRNOFFHandlers(BaseTest):
 
         forcefield = ForceField()
         forcefield.register_parameter_handler(bond_handler)
-        bond_potentials, _ = SMIRNOFFBondHandler._from_toolkit(
-            bond_handler=forcefield["Bonds"],
+        bond_potentials = SMIRNOFFBondHandler._from_toolkit(
+            parameter_handler=forcefield["Bonds"],
             topology=top,
         )
 
@@ -232,35 +233,28 @@ class TestSMIRNOFFHandlers(BaseTest):
 
 class TestConstraints:
     @pytest.mark.parametrize(
-        "constrained,mol,n_constraints",
+        "mol,n_constraints",
         [
-            (True, "C", 4),
-            (False, "C", 0),
-            (True, "CC", 6),
-            (False, "CC", 0),
+            ("C", 4),
+            ("CC", 6),
         ],
     )
-    def test_num_constraints(self, constrained, mol, n_constraints):
-        if constrained:
-            force_field = ForceField("openff-1.0.0.offxml")
-        else:
-            force_field = ForceField("openff_unconstrained-1.0.0.offxml")
+    def test_num_constraints(self, mol, n_constraints):
+        force_field = ForceField("openff-1.0.0.offxml")
 
         bond_handler = force_field["Bonds"]
-        constraint_handler = force_field["Constraints"] if constrained else None
+        constraint_handler = force_field["Constraints"]
 
         topology = Molecule.from_smiles(mol).to_topology()
 
-        _, constraints = SMIRNOFFBondHandler._from_toolkit(
-            bond_handler=bond_handler,
+        constraints = SMIRNOFFConstraintHandler._from_toolkit(
+            parameter_handler=[
+                val for val in [bond_handler, constraint_handler] if val is not None
+            ],
             topology=topology,
-            constraint_handler=constraint_handler,
         )
 
-        if constrained:
-            assert len(constraints.slot_map) == n_constraints
-        else:
-            assert constraints is None
+        assert len(constraints.slot_map) == n_constraints
 
 
 def test_library_charges_from_molecule():
@@ -290,10 +284,9 @@ class TestMatrixRepresentations(BaseTest):
         import jax
 
         if handler_name == "Bonds":
-            handler, _ = SMIRNOFFBondHandler._from_toolkit(
-                bond_handler=parsley["Bonds"],
+            handler = SMIRNOFFBondHandler._from_toolkit(
+                parameter_handler=parsley["Bonds"],
                 topology=ethanol_top,
-                constraint_handler=None,
             )
         elif handler_name == "Angles":
             handler = SMIRNOFFAngleHandler._from_toolkit(

--- a/openff/system/tests/interop/test_openmm.py
+++ b/openff/system/tests/interop/test_openmm.py
@@ -4,7 +4,6 @@ import pytest
 from openff.toolkit.tests.test_forcefield import create_ethanol
 from openff.toolkit.tests.utils import get_data_file_path
 from openff.toolkit.topology import Molecule, Topology
-from openff.toolkit.typing.engines.smirnoff import SMIRNOFFSpecError
 from simtk import openmm
 from simtk import unit as simtk_unit
 from simtk.openmm import app
@@ -13,6 +12,7 @@ from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.system import System
 from openff.system.drivers.openmm import _get_openmm_energies, get_openmm_energies
 from openff.system.exceptions import (
+    UnimplementedCutoffMethodError,
     UnsupportedCutoffMethodError,
     UnsupportedExportError,
 )
@@ -49,13 +49,13 @@ nonbonded_resolution_matrix = [
         "vdw_method": "cutoff",
         "electrostatics_method": "reaction-field",
         "periodic": True,
-        "result": SMIRNOFFSpecError,  # UnimplementedCutoffMethodError,
+        "result": UnimplementedCutoffMethodError,
     },
     {
         "vdw_method": "cutoff",
         "electrostatics_method": "reaction-field",
         "periodic": False,
-        "result": SMIRNOFFSpecError,  # UnimplementedCutoffMethodError,
+        "result": UnimplementedCutoffMethodError,
     },
 ]
 """\

--- a/openff/system/tests/interop/test_openmm.py
+++ b/openff/system/tests/interop/test_openmm.py
@@ -12,7 +12,6 @@ from openff.system.components.mdtraj import OFFBioTop
 from openff.system.components.system import System
 from openff.system.drivers.openmm import _get_openmm_energies, get_openmm_energies
 from openff.system.exceptions import (
-    UnimplementedCutoffMethodError,
     UnsupportedCutoffMethodError,
     UnsupportedExportError,
 )
@@ -45,6 +44,9 @@ nonbonded_resolution_matrix = [
         "periodic": False,
         "result": UnsupportedCutoffMethodError,
     },
+]
+# Revisit after OpenFF Toolkit >0.9.2 release
+"""
     {
         "vdw_method": "cutoff",
         "electrostatics_method": "reaction-field",
@@ -57,65 +59,6 @@ nonbonded_resolution_matrix = [
         "periodic": False,
         "result": UnimplementedCutoffMethodError,
     },
-]
-"""\
-    {
-        "vdw_method": "cutoff",
-        "electrostatics_method": "PME",
-        "has_periodic_box": False,
-        "omm_force": openmm.NonbondedForce.NoCutoff,
-        "exception": None,
-        "exception_match": "",
-    },
-    {
-        "vdw_method": "PME",
-        "electrostatics_method": "Coulomb",
-        "has_periodic_box": True,
-        "omm_force": None,
-        "exception": IncompatibleParameterError,
-        "exception_match": "",
-    },
-    {
-        "vdw_method": "PME",
-        "electrostatics_method": "Coulomb",
-        "has_periodic_box": False,
-        "omm_force": openmm.NonbondedForce.NoCutoff,
-        "exception": None,
-        "exception_match": "",
-    },
-    {
-        "vdw_method": "PME",
-        "electrostatics_method": "reaction-field",
-        "has_periodic_box": True,
-        "omm_force": None,
-        "exception": IncompatibleParameterError,
-        "exception_match": "reaction-field",
-    },
-    {
-        "vdw_method": "PME",
-        "electrostatics_method": "reaction-field",
-        "has_periodic_box": False,
-        "omm_force": None,
-        "exception": SMIRNOFFSpecError,
-        "exception_match": "reaction-field",
-    },
-    {
-        "vdw_method": "PME",
-        "electrostatics_method": "PME",
-        "has_periodic_box": True,
-        "omm_force": openmm.NonbondedForce.LJPME,
-        "exception": None,
-        "exception_match": "",
-    },
-    {
-        "vdw_method": "PME",
-        "electrostatics_method": "PME",
-        "has_periodic_box": False,
-        "omm_force": openmm.NonbondedForce.NoCutoff,
-        "exception": None,
-        "exception_match": "",
-    },
-]
 """
 
 


### PR DESCRIPTION
### Description
#200 make it more obvious that my earlier approach to handling constraints was inelegant. This PR splits off constraint handling into its own potential handler. The ugliness here is that the constraint handler depends on both a constraint handler from the toolkit and also a bond handler. Within the current SMIRNOFF spec, this is unavoidable, since constraints can be defined without also specifying their distance in the scope of the constraint handler.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
